### PR TITLE
Add custom configurable interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,24 @@ Or install it yourself as:
 gem install enmail
 ```
 
+## Configure
+
+The `EnMail` gem provides a very easier interface to set custom configurations
+or configure the underlying dependencies, we can configure it by adding an
+initializer with the following code
+
+```ruby
+EnMail.configure do |config|
+  config.certificates_path = "CERTIFICATES_ROOT_PAH"
+end
+```
+
+Or
+
+```ruby
+EnMail.configuration.certificates_path = "CERTIFICATES_ROOT_PAH"
+```
+
 ## Usage
 
 ```sh

--- a/lib/enmail.rb
+++ b/lib/enmail.rb
@@ -1,4 +1,5 @@
 require "enmail/version"
+require "enmail/config"
 
 module EnMail
   # Your code goes here...

--- a/lib/enmail/config.rb
+++ b/lib/enmail/config.rb
@@ -1,0 +1,21 @@
+require "enmail/configuration"
+
+module EnMail
+  module Config
+    def configure
+      if block_given?
+        yield configuration
+      end
+    end
+
+    def configuration
+      @configuration ||= EnMail::Configuration.new
+    end
+  end
+
+  # Expose config module methods as class level method, so we can
+  # use those method whenever necessary. Specially `configuration`
+  # throughout the gem
+  #
+  extend Config
+end

--- a/lib/enmail/configuration.rb
+++ b/lib/enmail/configuration.rb
@@ -1,0 +1,5 @@
+module EnMail
+  class Configuration
+    attr_accessor :certificates_path
+  end
+end

--- a/spec/enmail/config_spec.rb
+++ b/spec/enmail/config_spec.rb
@@ -1,0 +1,15 @@
+require "spec_helper"
+
+RSpec.describe EnMail::Config do
+  describe ".configure" do
+    it "allows us to set custom configuration" do
+      certificates_path = File.expand_path("../../fixtures", __FILE__)
+
+      EnMail.configure do |enmail_config|
+        enmail_config.certificates_path = certificates_path
+      end
+
+      expect(EnMail.configuration.certificates_path).to eq(certificates_path)
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,4 +9,13 @@ RSpec.configure do |config|
   config.expect_with :rspec do |c|
     c.syntax = :expect
   end
+
+  # Configure EnMail
+  #
+  config.before(:all) do
+    EnMail.configure do |enmail_config|
+      enmail_config.certificates_path =
+        File.expand_path("../fixtures/certificates", __FILE__)
+    end
+  end
 end


### PR DESCRIPTION
This commit adds the custom configurable interface for the `enamil` gem. User can provide their custom configuration using a block and passed it to the `.configure` or directly set the attributes value through the `.configuration`. Example

```ruby
EnMail.configure do |enamil_config|
  enamil_config.certificates_path = "CERTS_ROOT_PATH"
end
```