### PR TITLE
Add `#sign_message` configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ initializer with the following code
 
 ```ruby
 EnMail.configure do |config|
+  config.sign_message = true
   config.certificates_path = "CERTIFICATES_ROOT_PAH"
 end
 ```

--- a/lib/enmail/configuration.rb
+++ b/lib/enmail/configuration.rb
@@ -1,5 +1,20 @@
 module EnMail
   class Configuration
+    attr_accessor :sign_message
     attr_accessor :certificates_path
+
+    def initialize
+      @sign_message = true
+    end
+
+    # Signable?
+    #
+    # Returns the message signing status, by defualt it will return `true`.
+    # If the user provided a custom configuration for `sign_message` then
+    # it will use that status, so we can easily skip it when desirable.
+    #
+    def signable?
+      sign_message == true
+    end
   end
 end

--- a/spec/enmail/config_spec.rb
+++ b/spec/enmail/config_spec.rb
@@ -6,9 +6,11 @@ RSpec.describe EnMail::Config do
       certificates_path = File.expand_path("../../fixtures", __FILE__)
 
       EnMail.configure do |enmail_config|
+        enmail_config.sign_message = true
         enmail_config.certificates_path = certificates_path
       end
 
+      expect(EnMail.configuration.signable?).to be_truthy
       expect(EnMail.configuration.certificates_path).to eq(certificates_path)
     end
   end


### PR DESCRIPTION
Our main goal is to provide full control to the developer to chose what functionality they want to use based on their requirements. This configuration option will allow user to specify if they want the gem to sign their message or not, by default it is set to `true` but we can easily override it using the following configuration.

Note: We use the `configuration` as base option but it can also be overridden while invoking any interface.

```ruby
EnMail.configuration.sign_message = true
```