### PR TITLE
Add message signing related helper interfaces

### DIFF
--- a/lib/enmail/enmailable.rb
+++ b/lib/enmail/enmailable.rb
@@ -1,0 +1,30 @@
+module EnMail
+  module EnMailable
+    # Sign a message
+    #
+    # This interface allow us to sign a message while using this gem, this
+    # also forecefully sets the `signable` status true, so it ensures that
+    # the specific message will be signed before sending out.
+    #
+    # @param passphrase passphrase to use the private key.
+    #
+    def sign(passphrase = "")
+      @signable = true
+      @passphrase = passphrase
+    end
+
+    # Signing status
+    #
+    # This returns the message signing status based on the user specified
+    # configuration, by default it uses the default configuration.It will
+    # be overridden when we set the `signable` status on this instance.
+    #
+    def signable?
+      @signable || EnMail.configuration.signable?
+    end
+
+    private
+
+    attr_reader :signable, :passphrase
+  end
+end

--- a/spec/enmail/enmailable_spec.rb
+++ b/spec/enmail/enmailable_spec.rb
@@ -1,0 +1,32 @@
+require "spec_helper"
+require "enmail/enmailable"
+
+RSpec.describe "EnMail::TestEnMailble" do
+  describe "#signable?" do
+    context "without invoking #sign on message" do
+      it "usages the default configuration" do
+        EnMail.configuration.sign_message = false
+        enmailable = EnMail::TestEnMailble.new
+
+        expect(enmailable.signable?).to be_falsey
+      end
+    end
+
+    context "with explicity calling sign interface" do
+      it "sets the message signing status to true" do
+        EnMail.configuration.sign_message = false
+
+        enmailable = EnMail::TestEnMailble.new
+        enmailable.sign
+
+        expect(enmailable.signable?).to be_truthy
+      end
+    end
+  end
+
+  module EnMail
+    class TestEnMailble
+      include EnMail::EnMailable
+    end
+  end
+end


### PR DESCRIPTION
We need to invoke some custom interfaces to the mail instance so we can use those directly to the mail instance to sign, encrypt or decrypt an email message.

Instead of adding everything to the `Mail::Message` class, this commit adds a custom module where we will defined our customize behavior. This also implement a very simplest version of `sing` interface which takes an optional parameter.