### PR TITLE
Extend `Mail::Message` to support interfaces

### DIFF
--- a/lib/enmail/mail_ext/message.rb
+++ b/lib/enmail/mail_ext/message.rb
@@ -1,0 +1,18 @@
+require "mail"
+require "enmail/enmailable"
+
+module Mail
+  class Message
+    # Include enmail interfaces
+    #
+    # We are supporting some custom interfaces for the mail instance,
+    # so the user can use `sign`, `encrypt` and `decrypt` directly to
+    # their mail instance.
+    #
+    # The `EnMail::EnMailable` module defines all of the interfaces
+    # to support the above funcitonality, so let's include that and
+    # please check `EnMail::EnMailable` for more details on those.
+    #
+    include EnMail::EnMailable
+  end
+end

--- a/spec/enmail/mail_ext/message_spec.rb
+++ b/spec/enmail/mail_ext/message_spec.rb
@@ -1,0 +1,10 @@
+require "spec_helper"
+require "enmail/mail_ext/message"
+
+RSpec.describe "Mail::Message" do
+  describe "custom interfaces" do
+    it "includes EnMail::EnMailable module" do
+      expect(Mail::Message.included_modules).to include(EnMail::EnMailable)
+    end
+  end
+end


### PR DESCRIPTION
By default, user can use the default configuration to specify what they want to use from this gem, but they might also be interested in adding some mail specific behavior from message to message.

This commit extend the `Mail::Message` and include the interfaces so we can use those directly from any mail instance.