### PR TITLE
Add support for configurable SMIME adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ initializer with the following code
 ```ruby
 EnMail.configure do |config|
   config.sign_message = true
+  config.smime_adapter = :openssl
   config.certificates_path = "CERTIFICATES_ROOT_PAH"
 end
 ```

--- a/lib/enmail/configuration.rb
+++ b/lib/enmail/configuration.rb
@@ -1,10 +1,11 @@
 module EnMail
   class Configuration
-    attr_accessor :sign_message
-    attr_accessor :certificates_path
+    attr_reader :smime_adapter
+    attr_accessor :sign_message, :certificates_path
 
     def initialize
       @sign_message = true
+      @smime_adapter = :openssl
     end
 
     # Signable?
@@ -15,6 +16,36 @@ module EnMail
     #
     def signable?
       sign_message == true
+    end
+
+    # Set smime adapter
+    #
+    # This allows us to set a valid smime adapter, once this has been
+    # set then the gem will use this on to select the correct adapter
+    # class and then use that one to to `sign` a message.
+    #
+    # @param adapter adapter you want to use to sign the message
+    #
+    def smime_adapter=(adapter)
+      if valid_smime_adapter?(adapter)
+        @smime_adapter = adapter
+      end
+    end
+
+    private
+
+    def valid_smime_adapter?(adapter)
+      smime_adapters.include?(adapter.to_sym)
+    end
+
+    # Supported smime adapters
+    #
+    # The list of the supported smime adapters, if we add support for
+    # a new smime adapter then please update this list and this way we
+    # can ensure user can configure the gem with supported adapter only
+    #
+    def smime_adapters
+      [:openssl].freeze
     end
   end
 end

--- a/spec/enmail/config_spec.rb
+++ b/spec/enmail/config_spec.rb
@@ -14,4 +14,27 @@ RSpec.describe EnMail::Config do
       expect(EnMail.configuration.certificates_path).to eq(certificates_path)
     end
   end
+
+  describe "configuring adapter" do
+    context "with supported adapter" do
+      it "allows us to set the adapter" do
+        smime_adapter = :openssl
+
+        EnMail.configure do |config|
+          config.smime_adapter = smime_adapter
+        end
+
+        expect(EnMail.configuration.smime_adapter).to eq(smime_adapter)
+      end
+    end
+
+    context "with non supported adapter" do
+      it "usages the defualt adapter" do
+        invalid_adapter = :invalidadapter
+        EnMail.configuration.smime_adapter = invalid_adapter
+
+        expect(EnMail.configuration.smime_adapter).not_to be(invalid_adapter)
+      end
+    end
+  end
 end


### PR DESCRIPTION
This commit adds support for configurable SMIME adapter, by default we are using `openssl` but user can easily override this by providing a configuration with a valid supported adapter.

```ruby
EnMail.configure do |config|
  config.smime_adapter = :openssl
end
```