### PR TITLE
Add `secret_key` configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ initializer with the following code
 EnMail.configure do |config|
   config.sign_message = true
   config.smime_adapter = :openssl
+  config.secret_key = "Secret Key String"
+
   config.certificates_path = "CERTIFICATES_ROOT_PAH"
 end
 ```

--- a/lib/enmail/configuration.rb
+++ b/lib/enmail/configuration.rb
@@ -1,7 +1,7 @@
 module EnMail
   class Configuration
     attr_reader :smime_adapter
-    attr_accessor :sign_message, :certificates_path
+    attr_accessor :sign_message, :certificates_path, :secret_key
 
     def initialize
       @sign_message = true

--- a/spec/enmail/config_spec.rb
+++ b/spec/enmail/config_spec.rb
@@ -7,10 +7,12 @@ RSpec.describe EnMail::Config do
 
       EnMail.configure do |enmail_config|
         enmail_config.sign_message = true
+        enmail_config.secret_key = "Secret key content"
         enmail_config.certificates_path = certificates_path
       end
 
       expect(EnMail.configuration.signable?).to be_truthy
+      expect(EnMail.configuration.secret_key).not_to be_nil
       expect(EnMail.configuration.certificates_path).to eq(certificates_path)
     end
   end


### PR DESCRIPTION
By default, we are expecting user to set one secret_key that we will use to `sign/encrypt` any message. This is just a default, so if the user don't explicitly specify any key when invoking `sign` interface then we will use this one.

One important thing to note, we are expecting the key as string. For simplicity, we are not going into any of keyring implementation, all we need from user is to pass their key as string. If the secret key requires a passphrase then user needs to pass it when invoking the `sign` or any other interface that will use this key.

This is the simplest implementation for now, but there are lots of use case scenario will follow later.

```ruby
EnMail.configure do |config|
  config.secret_key = "String content for secret key"
end
```