### PR TITLE
Add signing key to message instance

### DIFF
--- a/lib/enmail/enmailable.rb
+++ b/lib/enmail/enmailable.rb
@@ -8,23 +8,30 @@ module EnMail
     #
     # @param passphrase passphrase to use the private key.
     #
-    def sign(passphrase = "")
-      @signable = true
+    def sign(passphrase: "", key: nil)
+      @key = key
       @passphrase = passphrase
+    end
+
+    # Signing key
+    #
+    # This returns the signing key when applicable, the default signing
+    # key is configured through an initializer, but we are also allowing
+    # user to provide a custom key when they are invoking an interface.
+    #
+    def signing_key
+      @key || EnMail.configuration.secret_key
     end
 
     # Signing status
     #
     # This returns the message signing status based on the user specified
-    # configuration, by default it uses the default configuration.It will
-    # be overridden when we set the `signable` status on this instance.
+    # configuration and signing key. If the user enabled sign_message and
+    # provided a valid signing key then this will return true otherwise
+    # false, this can be used before trying to sing a message.
     #
     def signable?
-      @signable || EnMail.configuration.signable?
+      signing_key && EnMail.configuration.signable?
     end
-
-    private
-
-    attr_reader :signable, :passphrase
   end
 end

--- a/spec/enmail/enmailable_spec.rb
+++ b/spec/enmail/enmailable_spec.rb
@@ -2,24 +2,52 @@ require "spec_helper"
 require "enmail/enmailable"
 
 RSpec.describe "EnMail::TestEnMailble" do
-  describe "#signable?" do
-    context "without invoking #sign on message" do
-      it "usages the default configuration" do
-        EnMail.configuration.sign_message = false
-        enmailable = EnMail::TestEnMailble.new
+  describe "#signing_key" do
+    context "custom key provided" do
+      it "returns the custom key as signing key" do
+        custom_key = "custom secret key"
+        EnMail.configuration.secret_key = "default_key"
+        message = EnMail::TestEnMailble.new
 
-        expect(enmailable.signable?).to be_falsey
+        message.sign(key: custom_key)
+
+        expect(message.signing_key).to eq(custom_key)
       end
     end
 
-    context "with explicity calling sign interface" do
-      it "sets the message signing status to true" do
-        EnMail.configuration.sign_message = false
+    context "without any key provided" do
+      it "returns the default configuration" do
+        default_key = "default secret key"
+        EnMail.configuration.secret_key = default_key
+        message = EnMail::TestEnMailble.new
 
-        enmailable = EnMail::TestEnMailble.new
-        enmailable.sign
+        message.sign
 
-        expect(enmailable.signable?).to be_truthy
+        expect(message.signing_key).to eq(default_key)
+      end
+    end
+  end
+
+  describe "#signable?" do
+    context "without a signing_key" do
+      it "returns false" do
+        EnMail.configuration.secret_key = nil
+        message = EnMail::TestEnMailble.new
+
+        message.sign
+
+        expect(message.signable?).to be_falsey
+      end
+    end
+
+    context "with a valid signing key" do
+      it "returns true" do
+        EnMail.configuration.sign_message = true
+        message = EnMail::TestEnMailble.new
+
+        message.sign(key: "valid signing key")
+
+        expect(message.signable?).to be_truthy
       end
     end
   end


### PR DESCRIPTION
By default user is configuring a `secret_key` to sign/encrypt any messages, but they might also want to provide different key in some use case scenario.

This commit adds the support to provide a key with `#sign` and if they do then we are using that key as `signing_key` and if there is no key then we will use the default one.

This also changes the `#signable?` interface, now it checks both the `sign_message` configuration and signing key, as with out a valid key a message can't be signed.