### PR TITLE
Retrieve the configured adapter klass

### DIFF
--- a/lib/enmail/configuration.rb
+++ b/lib/enmail/configuration.rb
@@ -32,10 +32,25 @@ module EnMail
       end
     end
 
+    # Adapter klass name
+    #
+    # This returns the string class name for the configured smime
+    # adapter. We are lazely loading the adapter so this interface
+    # will return the string verion.  Please do not forget to use
+    # `Object.const_get` before invokng any method on it.
+    #
+    def smime_adapter_klass
+      smime_adapter_symbol_to_klass
+    end
+
     private
 
     def valid_smime_adapter?(adapter)
       smime_adapters.include?(adapter.to_sym)
+    end
+
+    def smime_adapter_symbol_to_klass
+      adapter_klasses.fetch(smime_adapter.to_sym)
     end
 
     # Supported smime adapters
@@ -46,6 +61,10 @@ module EnMail
     #
     def smime_adapters
       [:openssl].freeze
+    end
+
+    def adapter_klasses
+      { openssl: "EnMail::Adapters::OpenSSL" }
     end
   end
 end

--- a/spec/enmail/config_spec.rb
+++ b/spec/enmail/config_spec.rb
@@ -26,7 +26,9 @@ RSpec.describe EnMail::Config do
           config.smime_adapter = smime_adapter
         end
 
-        expect(EnMail.configuration.smime_adapter).to eq(smime_adapter)
+        expect(
+          EnMail.configuration.smime_adapter_klass,
+        ).to eq("EnMail::Adapters::OpenSSL")
       end
     end
 


### PR DESCRIPTION
User configures `smime_adapter` by passing a symbol or string, which is just the simplification of an actual adapter class. This commit adds an interface to retrieve the adapter class name using the user configuration.

One important thing to note, the returning name is a string, we did it so we can lazily load the adapters when necessary, so please use `Object.const_get` before invoking any method on it.