### PR TITLE
Add a key model to store key contents

### DIFF
--- a/lib/enmail.rb
+++ b/lib/enmail.rb
@@ -1,3 +1,4 @@
+require "enmail/key"
 require "enmail/config"
 require "enmail/certificate_finder"
 

--- a/lib/enmail/configuration.rb
+++ b/lib/enmail/configuration.rb
@@ -1,7 +1,8 @@
 module EnMail
   class Configuration
     attr_reader :smime_adapter
-    attr_accessor :sign_message, :certificates_path, :secret_key
+    attr_accessor :sign_message, :certificates_path
+    attr_accessor :sign_key, :encrypt_key
 
     def initialize
       @sign_message = true
@@ -41,6 +42,15 @@ module EnMail
     #
     def smime_adapter_klass
       smime_adapter_symbol_to_klass
+    end
+
+    # Default key
+    #
+    # This returns a Key instance with the configured keys.
+    # @return [EnMail::Key] the configured default key attributes.
+    #
+    def defualt_key
+      EnMail::Key.new(sign_key: sign_key, encrypt_key: encrypt_key)
     end
 
     private

--- a/lib/enmail/enmailable.rb
+++ b/lib/enmail/enmailable.rb
@@ -6,11 +6,15 @@ module EnMail
     # also forecefully sets the `signable` status true, so it ensures that
     # the specific message will be signed before sending out.
     #
-    # @param passphrase passphrase to use the private key.
+    # @param passphrase [String] the passphrase for the sign key
+    # @param key [EnMail::Key] the key model instance
     #
     def sign(passphrase: "", key: nil)
       @key = key
-      @passphrase = passphrase
+
+      unless passphrase.empty?
+        signing_key.passphrase = passphrase
+      end
     end
 
     # Signing key
@@ -19,8 +23,10 @@ module EnMail
     # key is configured through an initializer, but we are also allowing
     # user to provide a custom key when they are invoking an interface.
     #
+    # @return [EnMail::Key] the key model instance
+    #
     def signing_key
-      @key || EnMail.configuration.secret_key
+      @key || EnMail.configuration.defualt_key
     end
 
     # Signing status
@@ -31,7 +37,7 @@ module EnMail
     # false, this can be used before trying to sing a message.
     #
     def signable?
-      signing_key && EnMail.configuration.signable?
+      signing_key.sign_key && EnMail.configuration.signable?
     end
   end
 end

--- a/lib/enmail/key.rb
+++ b/lib/enmail/key.rb
@@ -1,0 +1,53 @@
+module EnMail
+  class Key
+    # @!attribute [r] sign_key
+    #   @return [String] the signing key content
+    #
+    attr_reader :sign_key
+
+    # @!attribute passphrase
+    #   @return [String] the signing key passphrase
+    #
+    attr_reader :passphrase
+
+    # @!attribute [r] encrypt_key
+    #   @return [String] the encryping key content
+    #
+    attr_reader :encrypt_key
+
+    # @!attribute [r] certificate
+    #   @return [String] the certificate content
+    #
+    attr_reader :certificate
+
+    # Initialize a key model with the basic attributes, this expects us
+    # to provided the key/certificate as string and when we actually use
+    # it then the configured adapter will use it as necessary.
+    #
+    # @param :sign_key [String] the signing key content
+    # @param :passphrase [String] the passphrase for encrypted key
+    # @param :encrypt_key [String] the encryping key content
+    # @param :certificate [String] the signing certificate content
+    #
+    # @return [EnMail::Key] - the EnMail::Key model
+    #
+    def initialize(attributes)
+      @sign_key = attributes.fetch(:sign_key, "")
+      @passphrase = attributes.fetch(:passphrase, "")
+      @encrypt_key = attributes.fetch(:encrypt_key, "")
+      @certificate = attributes.fetch(:certificate, "")
+    end
+
+    # Set the passphrase value
+    #
+    # This allow us to set the passphrase after initialization, so if the
+    # user prefere then they can pass the passphrase during the siging /
+    # encrypting steps and we can set that one when necessary
+    #
+    # @param passphrase [String] the passphrase for encrypted key
+    #
+    def passphrase=(passphrase)
+      @passphrase = passphrase
+    end
+  end
+end

--- a/spec/enmail/config_spec.rb
+++ b/spec/enmail/config_spec.rb
@@ -7,12 +7,14 @@ RSpec.describe EnMail::Config do
 
       EnMail.configure do |enmail_config|
         enmail_config.sign_message = true
-        enmail_config.secret_key = "Secret key content"
+        enmail_config.sign_key = "Signing key content"
+        enmail_config.encrypt_key = "Encryping key content"
         enmail_config.certificates_path = certificates_path
       end
 
       expect(EnMail.configuration.signable?).to be_truthy
-      expect(EnMail.configuration.secret_key).not_to be_nil
+      expect(EnMail.configuration.defualt_key.sign_key).not_to be_nil
+      expect(EnMail.configuration.defualt_key.encrypt_key).not_to be_nil
       expect(EnMail.configuration.certificates_path).to eq(certificates_path)
     end
   end

--- a/spec/enmail/enmailable_spec.rb
+++ b/spec/enmail/enmailable_spec.rb
@@ -5,10 +5,10 @@ RSpec.describe "EnMail::TestEnMailble" do
   describe "#signing_key" do
     context "custom key provided" do
       it "returns the custom key as signing key" do
-        custom_key = "custom secret key"
-        EnMail.configuration.secret_key = "default_key"
-        message = EnMail::TestEnMailble.new
+        EnMail.configuration.sign_key = "default_key"
+        custom_key = EnMail::Key.new(sign_key: "custom secret key")
 
+        message = EnMail::TestEnMailble.new
         message.sign(key: custom_key)
 
         expect(message.signing_key).to eq(custom_key)
@@ -18,12 +18,12 @@ RSpec.describe "EnMail::TestEnMailble" do
     context "without any key provided" do
       it "returns the default configuration" do
         default_key = "default secret key"
-        EnMail.configuration.secret_key = default_key
-        message = EnMail::TestEnMailble.new
+        EnMail.configuration.sign_key = default_key
 
+        message = EnMail::TestEnMailble.new
         message.sign
 
-        expect(message.signing_key).to eq(default_key)
+        expect(message.signing_key.sign_key).to eq(default_key)
       end
     end
   end
@@ -31,9 +31,9 @@ RSpec.describe "EnMail::TestEnMailble" do
   describe "#signable?" do
     context "without a signing_key" do
       it "returns false" do
-        EnMail.configuration.secret_key = nil
-        message = EnMail::TestEnMailble.new
+        EnMail.configuration.sign_key = nil
 
+        message = EnMail::TestEnMailble.new
         message.sign
 
         expect(message.signable?).to be_falsey
@@ -43,9 +43,10 @@ RSpec.describe "EnMail::TestEnMailble" do
     context "with a valid signing key" do
       it "returns true" do
         EnMail.configuration.sign_message = true
-        message = EnMail::TestEnMailble.new
+        sign_key = EnMail::Key.new(sign_key: "valid signing key")
 
-        message.sign(key: "valid signing key")
+        message = EnMail::TestEnMailble.new
+        message.sign(key: sign_key)
 
         expect(message.signable?).to be_truthy
       end

--- a/spec/enmail/key_spec.rb
+++ b/spec/enmail/key_spec.rb
@@ -1,0 +1,23 @@
+require "spec_helper"
+
+RSpec.describe EnMail::Key do
+  describe "attributes" do
+    it "responds to key attributes" do
+      key = EnMail::Key.new(key_attributes)
+
+      expect(key.sign_key).to eq(key_attributes[:sign_key])
+      expect(key.passphrase).to eq(key_attributes[:passphrase])
+      expect(key.encrypt_key).to eq(key_attributes[:encrypt_key])
+      expect(key.certificate).to eq(key_attributes[:certificate])
+    end
+  end
+
+  def key_attributes
+    @attributes ||= {
+      sign_key: "signing key content",
+      passphrase: "sign_key passphrase",
+      encrypt_key: "encryping key content",
+      certificate: "signing certificate content"
+    }
+  end
+end


### PR DESCRIPTION
The `Key` is one of the core attributes for this gem, we will use it in different steps in the adapter, so let's organize those in more structured way.

This commit adds a `EnMail::Key` model, which can be initialize by passing the key contents and instead of parsing those it will keep those content as it is. The adapter will do the necessary work to read or use the correct key/certificate from this instance.