### PR TITLE
Support Open PGP message signing via GPGME (incomplete)

### DIFF
--- a/enmail.gemspec
+++ b/enmail.gemspec
@@ -28,4 +28,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "pry", "~>0.10.3"
+
+  spec.add_development_dependency "gpgme"
 end

--- a/lib/enmail.rb
+++ b/lib/enmail.rb
@@ -2,6 +2,8 @@ require "mail"
 
 require "enmail/version"
 
+require "enmail/adapters/gpgme"
+
 module EnMail
   # Your code goes here...
 end

--- a/lib/enmail.rb
+++ b/lib/enmail.rb
@@ -5,5 +5,10 @@ require "enmail/version"
 require "enmail/adapters/gpgme"
 
 module EnMail
-  # Your code goes here...
+  module_function
+
+  def protect(mode, message, **options)
+    adapter = Adapters::GPGME.new(options)
+    adapter.public_send mode, message
+  end
 end

--- a/lib/enmail/adapters/gpgme.rb
+++ b/lib/enmail/adapters/gpgme.rb
@@ -1,0 +1,24 @@
+module EnMail
+  module Adapters
+    # Secures e-mails according to {RFC 3156 "MIME Security with OpenPGP"}[
+    # https://tools.ietf.org/html/rfc3156].
+    #
+    # This adapter uses {GnuPG Made Easy (GPGME)}[
+    # https://www.gnupg.org/software/gpgme/index.html] library via interface
+    # provided by {gpgme gem}[https://github.com/ueno/ruby-gpgme].
+    class GPGME
+      attr_reader :options
+
+      def initialize(options)
+        @options = options
+      end
+
+      # TODO Sign
+      # TODO Handle multi-part messages
+      # TODO Copy MIME headers to signed part (ones which start with "Content-")
+      # TODO Ensure correct Content-Transfer-Encoding (as defined in RFC)
+      # TODO Preserve Content-Transfer-Encoding when possible
+      def sign(message); end
+    end
+  end
+end

--- a/lib/enmail/adapters/gpgme.rb
+++ b/lib/enmail/adapters/gpgme.rb
@@ -1,3 +1,5 @@
+require "gpgme"
+
 module EnMail
   module Adapters
     # Secures e-mails according to {RFC 3156 "MIME Security with OpenPGP"}[
@@ -49,12 +51,20 @@ module EnMail
         part
       end
 
-      def build_signature_part(_part_to_sign)
-        signature = "DUMMY_SIGNATURE"
+      def build_signature_part(part_to_sign)
+        signature = compute_signature(part_to_sign.encoded).to_s
         part = ::Mail::Part.new
         part.content_type = sign_protocol
         part.body = signature
         part
+      end
+
+      def compute_signature(text)
+        build_crypto.detach_sign(text)
+      end
+
+      def build_crypto
+        ::GPGME::Crypto.new(armor: true)
       end
 
       public

--- a/lib/enmail/adapters/gpgme.rb
+++ b/lib/enmail/adapters/gpgme.rb
@@ -60,11 +60,17 @@ module EnMail
       public
 
       def signed_part_content_type
-        "multipart/signed"
+        protocol = sign_protocol
+        micalg = message_integrity_algorithm
+        %[multipart/signed; protocol="#{protocol}"; micalg="#{micalg}"]
       end
 
       def sign_protocol
         "application/pgp-signature"
+      end
+
+      def message_integrity_algorithm
+        "pgp-sha1"
       end
     end
   end

--- a/lib/enmail/adapters/gpgme.rb
+++ b/lib/enmail/adapters/gpgme.rb
@@ -13,12 +13,59 @@ module EnMail
         @options = options
       end
 
-      # TODO Sign
-      # TODO Handle multi-part messages
-      # TODO Copy MIME headers to signed part (ones which start with "Content-")
-      # TODO Ensure correct Content-Transfer-Encoding (as defined in RFC)
+      def sign(message)
+        part_to_be_signed = body_to_part(message)
+        signature_part = build_signature_part(part_to_be_signed)
+
+        message.body = nil
+        message.content_type = signed_part_content_type
+        message.add_part part_to_be_signed
+        message.add_part signature_part
+      end
+
+      private
+
+      # Returns a new +Mail::Part+ with the same content and MIME headers
+      # as the message passed as an argument.
+      #
+      # Although Mail gem provides +Mail::Message#convert_to_multipart+ method,
+      # it works correctly for non-multipart text/plain messages only.  This
+      # method is more robust, and handles messages containing any content type,
+      # be they multipart or not.
+      #
+      # The message passed as an argument is not altered.
+      #
+      # TODO Copy MIME headers (ones which start with "Content-")
       # TODO Preserve Content-Transfer-Encoding when possible
-      def sign(message); end
+      # TODO Set some safe Content-Transfer-Encoding, like quoted-printable
+      def body_to_part(message)
+        part = ::Mail::Part.new
+        part.content_type = message.content_type
+        if message.multipart?
+          message.body.parts.each { |p| part.add_part p.dup }
+        else
+          part.body = message.body.decoded
+        end
+        part
+      end
+
+      def build_signature_part(_part_to_sign)
+        signature = "DUMMY_SIGNATURE"
+        part = ::Mail::Part.new
+        part.content_type = sign_protocol
+        part.body = signature
+        part
+      end
+
+      public
+
+      def signed_part_content_type
+        "multipart/signed"
+      end
+
+      def sign_protocol
+        "application/pgp-signature"
+      end
     end
   end
 end

--- a/spec/acceptance/gpgme/sign_spec.rb
+++ b/spec/acceptance/gpgme/sign_spec.rb
@@ -1,0 +1,64 @@
+require "spec_helper"
+
+RSpec.describe "Signing with GPGME" do
+  include_context "example emails"
+
+  specify "a non-multipart text-only message" do
+    mail = simple_mail
+
+    EnMail.protect :sign, mail
+    mail.deliver
+    common_message_expectations(mail)
+    pgp_signed_part_expectations(mail)
+    decrypted_part_expectations_for_simple_mail(mail.parts[0])
+  end
+
+  specify "a non-multipart HTML message" do
+    mail = simple_html_mail
+
+    EnMail.protect :sign, mail
+    mail.deliver
+    common_message_expectations(mail)
+    pgp_signed_part_expectations(mail)
+    decrypted_part_expectations_for_simple_html_mail(mail.parts[0])
+  end
+
+  specify "a multipart text+HTML message" do
+    mail = text_html_mail
+
+    EnMail.protect :sign, mail
+    mail.deliver
+    common_message_expectations(mail)
+    pgp_signed_part_expectations(mail)
+    decrypted_part_expectations_for_text_html_mail(mail.parts[0])
+  end
+
+  specify "a multipart message with binary attachments" do
+    mail = text_jpeg_mail
+
+    EnMail.protect :sign, mail
+    mail.deliver
+    common_message_expectations(mail)
+    pgp_signed_part_expectations(mail)
+    decrypted_part_expectations_for_text_jpeg_mail(mail.parts[0])
+  end
+
+  def pgp_signed_part_expectations(message_or_part)
+    expect(message_or_part.mime_type).to eq("multipart/signed")
+    expect(message_or_part.content_type_parameters).to include(
+      "micalg" => "pgp-sha1",
+      "protocol" => "application/pgp-signature",
+    )
+    expect(message_or_part.parts.size).to eq(2)
+    expect(message_or_part.parts[1].mime_type).
+      to eq("application/pgp-signature")
+    expect(message_or_part.parts[1].content_type_parameters).to be_empty
+
+    ::GPGME::Crypto.new.verify(
+      message_or_part.parts[1].body.decoded,
+      signed_text: message_or_part.parts[0].encoded,
+    ) do |sig|
+      expect(sig).to be_valid
+    end
+  end
+end

--- a/spec/acceptance/without_enmail_spec.rb
+++ b/spec/acceptance/without_enmail_spec.rb
@@ -7,45 +7,31 @@ RSpec.describe "Sending without protection (unaltered by EnMail)" do
     mail = simple_mail
 
     mail.deliver
-    expect(mail.from).to contain_exactly(mail_from)
-    expect(mail.to).to contain_exactly(mail_to)
-    expect(mail.mime_type).to eq("text/plain")
-    expect(mail.body.decoded).to eq(mail_text)
+    common_message_expectations(mail)
+    decrypted_part_expectations_for_simple_mail(mail)
   end
 
   specify "a non-multipart HTML message" do
     mail = simple_html_mail
 
     mail.deliver
-    expect(mail.from).to contain_exactly(mail_from)
-    expect(mail.to).to contain_exactly(mail_to)
-    expect(mail.mime_type).to eq("text/html")
-    expect(mail.body.decoded).to eq(mail_html)
+    common_message_expectations(mail)
+    decrypted_part_expectations_for_simple_html_mail(mail)
   end
 
   specify "a multipart text+HTML message" do
     mail = text_html_mail
 
     mail.deliver
-    expect(mail.from).to contain_exactly(mail_from)
-    expect(mail.to).to contain_exactly(mail_to)
-    expect(mail.body.raw_source).to be_empty
-    expect(mail.parts[0].mime_type).to eq("text/plain")
-    expect(mail.parts[0].body.decoded).to eq(mail_text)
-    expect(mail.parts[1].mime_type).to eq("text/html")
-    expect(mail.parts[1].body.decoded).to eq(mail_html)
+    common_message_expectations(mail)
+    decrypted_part_expectations_for_text_html_mail(mail)
   end
 
   specify "a multipart message with binary attachments" do
     mail = text_jpeg_mail
 
     mail.deliver
-    expect(mail.from).to contain_exactly(mail_from)
-    expect(mail.to).to contain_exactly(mail_to)
-    expect(mail.body.raw_source).to be_empty
-    expect(mail.parts[0].mime_type).to eq("text/plain")
-    expect(mail.parts[0].body.decoded).to eq(mail_text)
-    expect(mail.parts[1].mime_type).to eq("image/jpeg")
-    expect(mail.parts[1].body.decoded).to eq(SMALLEST_JPEG)
+    common_message_expectations(mail)
+    decrypted_part_expectations_for_text_jpeg_mail(mail)
   end
 end

--- a/spec/support/example_emails.rb
+++ b/spec/support/example_emails.rb
@@ -15,6 +15,11 @@ shared_context "example emails" do
     m
   end
 
+  def decrypted_part_expectations_for_simple_mail(message_or_part)
+    expect(message_or_part.mime_type).to eq("text/plain")
+    expect(message_or_part.body.decoded).to eq(mail_text)
+  end
+
   let(:simple_html_mail) do
     m = Mail.new
     m.from = mail_from
@@ -24,6 +29,11 @@ shared_context "example emails" do
     m.body = mail_html
     m.content_type = "text/html"
     m
+  end
+
+  def decrypted_part_expectations_for_simple_html_mail(message_or_part)
+    expect(message_or_part.mime_type).to eq("text/html")
+    expect(message_or_part.body.decoded).to eq(mail_html)
   end
 
   let(:text_html_mail) do
@@ -37,6 +47,14 @@ shared_context "example emails" do
     m
   end
 
+  def decrypted_part_expectations_for_text_html_mail(message_or_part)
+    expect(message_or_part.body.raw_source).to be_empty
+    expect(message_or_part.parts[0].mime_type).to eq("text/plain")
+    expect(message_or_part.parts[0].body.decoded).to eq(mail_text)
+    expect(message_or_part.parts[1].mime_type).to eq("text/html")
+    expect(message_or_part.parts[1].body.decoded).to eq(mail_html)
+  end
+
   let(:text_jpeg_mail) do
     m = Mail.new
     m.from = mail_from
@@ -46,5 +64,19 @@ shared_context "example emails" do
     m.body = mail_text
     m.add_file filename: "pic.jpg", content: SMALLEST_JPEG
     m
+  end
+
+  def decrypted_part_expectations_for_text_jpeg_mail(message_or_part)
+    expect(message_or_part.body.raw_source).to be_empty
+    expect(message_or_part.parts[0].mime_type).to eq("text/plain")
+    expect(message_or_part.parts[0].body.decoded).to eq(mail_text)
+    expect(message_or_part.parts[1].mime_type).to eq("image/jpeg")
+    expect(message_or_part.parts[1].body.decoded).to eq(SMALLEST_JPEG)
+  end
+
+  def common_message_expectations(message)
+    expect(message.from).to contain_exactly(mail_from)
+    expect(message.to).to contain_exactly(mail_to)
+    expect(message.subject).to eq(mail_subject)
   end
 end

--- a/spec/unit/adapters/gpgme_spec.rb
+++ b/spec/unit/adapters/gpgme_spec.rb
@@ -4,8 +4,100 @@ RSpec.describe EnMail::Adapters::GPGME do
   let(:adapter) { described_class.new(options) }
   let(:options) { {} }
 
+  include_context "example emails"
+
   describe "#sign" do
-    subject { described_class.instance_method(:sign) }
-    pending "write tests"
+    subject { adapter.method(:sign) }
+
+    let(:mail) { simple_mail }
+    let(:blank_string_rx) { /\A\s*\Z/ }
+    let(:msg_part_dbl) { double.as_null_object }
+    let(:sig_dbl) { double.as_null_object }
+
+    before do
+      allow(adapter).to receive(:body_to_part).and_return(msg_part_dbl)
+      allow(adapter).to receive(:build_signature_part).and_return(sig_dbl)
+    end
+
+    it "changes message mime type to multipart/signed" do
+      expect { subject.(mail) }.to(
+        change { mail.mime_type }.to("multipart/signed")
+      )
+    end
+
+    it "preserves from, to, subject, date, message id, and custom headers" do
+      mail.ready_to_send! # Set some default message_id
+      expect { subject.(mail) }.to(
+        preserve { mail.date } &
+        preserve { mail.from } &
+        preserve { mail.to } &
+        preserve { mail.subject } &
+        preserve { mail.message_id } &
+        preserve { mail.headers["custom"] }
+      )
+    end
+
+    it "clears the old message body" do
+      expect { subject.(mail) }.
+        to change { mail.body.decoded }.to(blank_string_rx)
+    end
+
+    it "converts the old message body to a a MIME part, and re-appends it " +
+      "to self" do
+      subject.(mail)
+      expect(adapter).to have_received(:body_to_part).with(mail)
+      expect(mail.parts[0]).to be(msg_part_dbl)
+    end
+
+    it "adds the signature as the 2nd MIME part" do
+      subject.(mail)
+      expect(adapter).to have_received(:build_signature_part).with(msg_part_dbl)
+      expect(mail.parts[1]).to be(sig_dbl)
+    end
+  end
+
+  describe "#body_to_part" do
+    subject { adapter.method(:body_to_part) }
+
+    it "converts an e-mail with unspecified content type to " +
+      "a text/plain MIME part, preserving its content" do
+      mail = simple_mail
+      retval = subject.(mail)
+      expect(retval).to be_instance_of(::Mail::Part)
+      expect(retval.mime_type).to eq(mail.mime_type) & eq(nil)
+      expect(retval.body.decoded).to eq(mail.body.decoded)
+    end
+
+    it "converts a non-multipart e-mail with specific content type to " +
+      "a MIME part, preserving its content and content type" do
+      mail = simple_html_mail
+      retval = subject.(mail)
+      expect(retval).to be_instance_of(::Mail::Part)
+      expect(retval.mime_type).to eq(mail.mime_type) & eq("text/html")
+      expect(retval.body.decoded).to eq(mail.body.decoded)
+    end
+
+    it "converts a multipart e-mail into a multipart MIME part, " +
+      "preserving its content and content type" do
+      mail = text_jpeg_mail
+      retval = subject.(mail)
+      expect(retval).to be_instance_of(::Mail::Part)
+      expect(retval.mime_type).to eq(mail.mime_type)
+      expect(retval.parts.size).to eq(mail.parts.size) & eq(2)
+      expect(retval.parts[0]).to eq(mail.parts[0])
+      expect(retval.parts[1]).to eq(mail.parts[1])
+    end
+  end
+
+  describe "#build_signature_part" do
+    subject { adapter.method(:build_signature_part) }
+    let(:part) { ::Mail::Part.new(body: "Some Text.") }
+
+    it "builds a MIME part with correct content type" do
+      retval = subject.(part)
+      expect(retval).to be_instance_of(::Mail::Part)
+      expect(retval.mime_type).to eq("application/pgp-signature")
+      expect(retval.body.decoded).to eq("DUMMY_SIGNATURE")
+    end
   end
 end

--- a/spec/unit/adapters/gpgme_spec.rb
+++ b/spec/unit/adapters/gpgme_spec.rb
@@ -92,12 +92,13 @@ RSpec.describe EnMail::Adapters::GPGME do
   describe "#build_signature_part" do
     subject { adapter.method(:build_signature_part) }
     let(:part) { ::Mail::Part.new(body: "Some Text.") }
+    let(:signature_rx) { %r{\A-+BEGIN PGP SIGNATURE.*END PGP SIGNATURE-+\Z}m }
 
     it "builds a MIME part with correct content type" do
       retval = subject.(part)
       expect(retval).to be_instance_of(::Mail::Part)
       expect(retval.mime_type).to eq("application/pgp-signature")
-      expect(retval.body.decoded).to eq("DUMMY_SIGNATURE")
+      expect(retval.body.decoded).to match(signature_rx)
     end
   end
 

--- a/spec/unit/adapters/gpgme_spec.rb
+++ b/spec/unit/adapters/gpgme_spec.rb
@@ -100,4 +100,29 @@ RSpec.describe EnMail::Adapters::GPGME do
       expect(retval.body.decoded).to eq("DUMMY_SIGNATURE")
     end
   end
+
+  describe "#signed_part_content_type" do
+    subject { adapter.method(:signed_part_content_type) }
+
+    it "returns a string" do
+      expect(subject.call).to be_a(String)
+    end
+
+    it "has a MIME type multipart/signed" do
+      retval_segments = subject.call.split(/\s*;\s*/)
+      expect(retval_segments[0]).to eq("multipart/signed")
+    end
+
+    it "tells about SHA1 message integrity algorithm" do
+      retval_segments = subject.call.split(/\s*;\s*/)
+      micalg_def = %[micalg="pgp-sha1"]
+      expect(retval_segments[1..-1]).to include(micalg_def)
+    end
+
+    it "tells about PGP protocol" do
+      retval_segments = subject.call.split(/\s*;\s*/)
+      protocol_def = %[protocol="application/pgp-signature"]
+      expect(retval_segments[1..-1]).to include(protocol_def)
+    end
+  end
 end

--- a/spec/unit/adapters/gpgme_spec.rb
+++ b/spec/unit/adapters/gpgme_spec.rb
@@ -1,0 +1,11 @@
+require "spec_helper"
+
+RSpec.describe EnMail::Adapters::GPGME do
+  let(:adapter) { described_class.new(options) }
+  let(:options) { {} }
+
+  describe "#sign" do
+    subject { described_class.instance_method(:sign) }
+    pending "write tests"
+  end
+end

--- a/spec/unit/enmail_spec.rb
+++ b/spec/unit/enmail_spec.rb
@@ -1,0 +1,21 @@
+RSpec.describe EnMail do
+  describe "::protect" do
+    subject { EnMail.method(:protect) }
+
+    let(:adapter_class) { EnMail::Adapters::GPGME }
+    let(:adapter_dbl) { instance_double(adapter_class, sign: nil) }
+    let(:message) { Mail.new }
+
+    before { allow(adapter_class).to receive(:new).and_return(adapter_dbl) }
+
+    it "instantiates an adapter with proper options" do
+      subject.call :sign, message, proper: :options
+      expect(adapter_class).to have_received(:new).with(proper: :options)
+    end
+
+    it "calls indicated method, passing a message as an argument" do
+      subject.call :sign, message
+      expect(adapter_dbl).to have_received(:sign).with(message)
+    end
+  end
+end


### PR DESCRIPTION
This pull request brings an incomplete, and basic support for message signing with GPG Made Easy library, as defined in RFC 3156 "MIME Security with OpenPGP", with following reservations:

* The message format does not fully comply with RFC.  The RFC [makes restrictions](https://tools.ietf.org/html/rfc3156#section-3) on Content-Transfer-Encoding, which are not fulfilled yet.  It was quite a struggle (see: https://github.com/mikel/mail/issues/1226), so far without success, but I got some ideas how to fix that.  I don't think that mail-gpg gem fulfills this requirement either.

* So far no ability to choose a key to use, nor to specify a password.  Gem is pretty useless without that, it will be fixed.

* Tests do not pass on Travis CI, though they do in local environment.  The reason is that user is prompted for password (GPGME dialog), and that Travis has its own password-protected PGP keys.  Tests will be fixed along with providing better key management (see previous point).
