### PR TITLE
Generate and use test GPG keys

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,9 @@ rvm:
 before_install:
   - gem install bundler -v 1.16.1
 
+before_script:
+  - rake generate_gpg_keys
+
 matrix:
   allow_failures:
     - rvm: ruby-head

--- a/Rakefile
+++ b/Rakefile
@@ -4,3 +4,26 @@ require "rspec/core/rake_task"
 RSpec::Core::RakeTask.new(:spec)
 
 task :default => :spec
+
+# Available parameters for unattended GPG key generation are described here:
+# https://www.gnupg.org/documentation/manuals/gnupg/Unattended-GPG-key-generation.html
+task :generate_gpg_keys => :init_gpgme do
+  ::GPGME::Ctx.new.genkey(<<~EOS)
+    <GnupgKeyParms format="internal">
+    %no-protection
+    Key-Type: DSA
+    Key-Length: 2048
+    Subkey-Type: ELG-E
+    Subkey-Length: 2048
+    Name-Real: Cato Elder
+    Name-Email: cato.elder@example.test
+    Name-Comment: Without passphrase
+    Expire-Date: 0
+    </GnupgKeyParms>
+  EOS
+end
+
+task :init_gpgme do
+  require "gpgme"
+  require_relative "./spec/support/gpgme_setup"
+end

--- a/spec/support/gpgme_setup.rb
+++ b/spec/support/gpgme_setup.rb
@@ -1,0 +1,7 @@
+# Keep tmp directory as short as possible.  UNIX has some annoying limit
+# on file name length of the socket, and GPGME makes use of UNIX sockets.
+# Directory name produced by +Dir.mktmpdir+ is often quite long, and that
+# may cause weird error with misleading message.
+tmp_gpgme_home = File.expand_path("../../tmp/gpgme", __dir__)
+FileUtils.mkdir_p(tmp_gpgme_home)
+GPGME::Engine.home_dir = tmp_gpgme_home


### PR DESCRIPTION
When testing, use a non-standard GPG home location (`tmp/gpgme`). Use Rake to generate test keys into that location.