### PR TITLE
Sign messages with any key

### DIFF
--- a/lib/enmail/adapters/gpgme.rb
+++ b/lib/enmail/adapters/gpgme.rb
@@ -17,7 +17,7 @@ module EnMail
 
       def sign(message)
         part_to_be_signed = body_to_part(message)
-        signer = message.from_addrs.first
+        signer = find_signer_for(message)
         signature_part = build_signature_part(part_to_be_signed, signer)
 
         message.body = nil
@@ -62,6 +62,10 @@ module EnMail
 
       def compute_signature(text, signer)
         build_crypto.detach_sign(text, signer: signer)
+      end
+
+      def find_signer_for(message)
+        message.from_addrs.first
       end
 
       def build_crypto

--- a/lib/enmail/adapters/gpgme.rb
+++ b/lib/enmail/adapters/gpgme.rb
@@ -65,7 +65,7 @@ module EnMail
       end
 
       def find_signer_for(message)
-        message.from_addrs.first
+        options[:signer] || message.from_addrs.first
       end
 
       def build_crypto

--- a/spec/acceptance/gpgme/sign_spec.rb
+++ b/spec/acceptance/gpgme/sign_spec.rb
@@ -43,6 +43,17 @@ RSpec.describe "Signing with GPGME" do
     decrypted_part_expectations_for_text_jpeg_mail(mail.parts[0])
   end
 
+  specify "forcing different signer key" do
+    mail = simple_mail
+    signer = "whatever@example.test"
+
+    EnMail.protect :sign, mail, signer: signer
+    mail.deliver
+    common_message_expectations(mail)
+    pgp_signed_part_expectations(mail, expected_signer: signer)
+    decrypted_part_expectations_for_simple_mail(mail.parts[0])
+  end
+
   def pgp_signed_part_expectations(message_or_part, expected_signer: mail_from)
     expect(message_or_part.mime_type).to eq("multipart/signed")
     expect(message_or_part.content_type_parameters).to include(

--- a/spec/acceptance/gpgme/sign_spec.rb
+++ b/spec/acceptance/gpgme/sign_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe "Signing with GPGME" do
     decrypted_part_expectations_for_text_jpeg_mail(mail.parts[0])
   end
 
-  def pgp_signed_part_expectations(message_or_part)
+  def pgp_signed_part_expectations(message_or_part, expected_signer: mail_from)
     expect(message_or_part.mime_type).to eq("multipart/signed")
     expect(message_or_part.content_type_parameters).to include(
       "micalg" => "pgp-sha1",
@@ -56,6 +56,6 @@ RSpec.describe "Signing with GPGME" do
 
     expect(message_or_part.parts[1].body.decoded).
       to be_a_valid_pgp_signature_of(message_or_part.parts[0].encoded).
-      signed_by(mail_from)
+      signed_by(expected_signer)
   end
 end


### PR DESCRIPTION
By default, the signer key is determined basing on message's from field.  However, since now that can be overriden by specifying any other key via `:signer` option.