### PR TITLE
Support password-protected keys when signing messages

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -7,7 +7,9 @@ task :default => :spec # rubocop:disable Style/HashSyntax
 
 # Available parameters for unattended GPG key generation are described here:
 # https://www.gnupg.org/documentation/manuals/gnupg/Unattended-GPG-key-generation.html
-task :generate_pgp_keys => :init_gpgme do # rubocop:disable Style/HashSyntax
+# rubocop:disable Style/HashSyntax
+# rubocop:disable Metrics/BlockLength
+task :generate_pgp_keys => :init_gpgme do
   # Key pairs without password
   ::GPGME::Ctx.new.genkey(<<~SCRIPT)
     <GnupgKeyParms format="internal">
@@ -66,6 +68,8 @@ task :generate_pgp_keys => :init_gpgme do # rubocop:disable Style/HashSyntax
     </GnupgKeyParms>
   SCRIPT
 end
+# rubocop:enable Style/HashSyntax
+# rubocop:enable Metrics/BlockLength
 
 task :init_gpgme do
   require "gpgme"

--- a/Rakefile
+++ b/Rakefile
@@ -8,6 +8,7 @@ task :default => :spec # rubocop:disable Style/HashSyntax
 # Available parameters for unattended GPG key generation are described here:
 # https://www.gnupg.org/documentation/manuals/gnupg/Unattended-GPG-key-generation.html
 task :generate_pgp_keys => :init_gpgme do # rubocop:disable Style/HashSyntax
+  # Key pairs without password
   ::GPGME::Ctx.new.genkey(<<~SCRIPT)
     <GnupgKeyParms format="internal">
     %no-protection
@@ -45,6 +46,23 @@ task :generate_pgp_keys => :init_gpgme do # rubocop:disable Style/HashSyntax
     Name-Email: senate@example.test
     Name-Comment: Without passphrase
     Expire-Date: 0
+    </GnupgKeyParms>
+  SCRIPT
+
+  # Password-protected key pairs
+  ::GPGME::Ctx.new.genkey(<<~SCRIPT)
+    <GnupgKeyParms format="internal">
+    Key-Type: RSA
+    Key-Usage: sign, cert
+    Key-Length: 2048
+    Subkey-Type: RSA
+    Subkey-Length: 2048
+    Subkey-Usage: encrypt
+    Name-Real: Cato Elder
+    Name-Email: cato.elder+pwd@example.test
+    Name-Comment: Password-protected
+    Expire-Date: 0
+    Passphrase: 1234
     </GnupgKeyParms>
   SCRIPT
 end

--- a/lib/enmail/adapters/gpgme.rb
+++ b/lib/enmail/adapters/gpgme.rb
@@ -16,7 +16,11 @@ module EnMail
       private
 
       def compute_signature(text, signer)
-        build_crypto.detach_sign(text, signer: signer)
+        build_crypto.detach_sign(
+          text,
+          signer: signer,
+          password: options[:key_password],
+        )
       end
 
       def encrypt_string(text, recipients)
@@ -29,6 +33,7 @@ module EnMail
           sign: true,
           signers: [signer],
           recipients: recipients,
+          password: options[:key_password],
         )
       end
 

--- a/lib/enmail/adapters/gpgme.rb
+++ b/lib/enmail/adapters/gpgme.rb
@@ -33,7 +33,10 @@ module EnMail
       end
 
       def build_crypto
-        ::GPGME::Crypto.new(armor: true)
+        ::GPGME::Crypto.new(
+          armor: true,
+          pinentry_mode: ::GPGME::PINENTRY_MODE_LOOPBACK,
+        )
       end
     end
   end

--- a/lib/enmail/adapters/rnp.rb
+++ b/lib/enmail/adapters/rnp.rb
@@ -87,6 +87,8 @@ module EnMail
           rnp.load_keys(format: keyring_info[:format], input: input)
         end
 
+        rnp.password_provider = options[:key_password]
+
         rnp
       end
     end

--- a/lib/enmail/adapters/rnp.rb
+++ b/lib/enmail/adapters/rnp.rb
@@ -76,8 +76,6 @@ module EnMail
       end
 
       def build_rnp_and_load_keys
-        homedir = options[:homedir] || Rnp.default_homedir
-        homedir_info = ::Rnp.homedir_info(homedir)
         public_info, secret_info = homedir_info.values_at(:public, :secret)
 
         rnp = Rnp.new(public_info[:format], secret_info[:format])
@@ -90,6 +88,11 @@ module EnMail
         rnp.password_provider = options[:key_password]
 
         rnp
+      end
+
+      def homedir_info
+        @homedir_info ||=
+          ::Rnp.homedir_info(options[:homedir] || Rnp.default_homedir)
       end
     end
   end

--- a/spec/acceptance/gpgme/sign_and_encrypt_combined_spec.rb
+++ b/spec/acceptance/gpgme/sign_and_encrypt_combined_spec.rb
@@ -67,4 +67,18 @@ RSpec.describe "Signing and encrypting in combined fashion with GPGME" do
     decrypted_mail = decrypt_mail(mail)
     decrypted_part_expectations_for_simple_mail(decrypted_mail)
   end
+
+  specify "with a password-protected signer key" do
+    mail = simple_mail
+    signer = "cato.elder+pwd@example.test"
+
+    EnMail.protect :sign_and_encrypt_combined, mail, adapter: adapter_class,
+                                                     signer: signer,
+                                                     key_password: "1234"
+    mail.deliver
+    common_message_expectations(mail)
+    pgp_signed_and_encrypted_part_expectations(mail, expected_signer: signer)
+    decrypted_mail = decrypt_mail(mail)
+    decrypted_part_expectations_for_simple_mail(decrypted_mail)
+  end
 end

--- a/spec/acceptance/gpgme/sign_and_encrypt_encapsulated_spec.rb
+++ b/spec/acceptance/gpgme/sign_and_encrypt_encapsulated_spec.rb
@@ -72,4 +72,19 @@ RSpec.describe "Signing and encrypting in encapsulated fashion with GPGME" do
     pgp_signed_part_expectations(decrypted_mail, expected_signer: signer)
     decrypted_part_expectations_for_simple_mail(decrypted_mail.parts[0])
   end
+
+  specify "with a password-protected signer key" do
+    mail = simple_mail
+    signer = "cato.elder+pwd@example.test"
+
+    EnMail.protect :sign_and_encrypt_encapsulated, mail, adapter: adapter_class,
+                                                         signer: signer,
+                                                         key_password: "1234"
+    mail.deliver
+    common_message_expectations(mail)
+    pgp_encrypted_part_expectations(mail)
+    decrypted_mail = decrypt_mail(mail)
+    pgp_signed_part_expectations(decrypted_mail, expected_signer: signer)
+    decrypted_part_expectations_for_simple_mail(decrypted_mail.parts[0])
+  end
 end

--- a/spec/acceptance/gpgme/sign_spec.rb
+++ b/spec/acceptance/gpgme/sign_spec.rb
@@ -61,4 +61,16 @@ RSpec.describe "Signing with GPGME" do
     pgp_signed_part_expectations(mail, expected_signer: signer)
     decrypted_part_expectations_for_simple_mail(mail.parts[0])
   end
+
+  specify "with a password-protected signer key" do
+    mail = simple_mail
+    signer = "cato.elder+pwd@example.test"
+
+    EnMail.protect :sign, mail, adapter: adapter_class, signer: signer,
+                                key_password: "1234"
+    mail.deliver
+    common_message_expectations(mail)
+    pgp_signed_part_expectations(mail, expected_signer: signer)
+    decrypted_part_expectations_for_simple_mail(mail.parts[0])
+  end
 end

--- a/spec/acceptance/rnp/sign_and_encrypt_combined_spec.rb
+++ b/spec/acceptance/rnp/sign_and_encrypt_combined_spec.rb
@@ -67,4 +67,18 @@ RSpec.describe "Signing and encrypting in combined fashion with RNP" do
     decrypted_mail = decrypt_mail(mail)
     decrypted_part_expectations_for_simple_mail(decrypted_mail)
   end
+
+  specify "with a password-protected signer key" do
+    mail = simple_mail
+    signer = "cato.elder+pwd@example.test"
+
+    EnMail.protect :sign_and_encrypt_combined, mail, adapter: adapter_class,
+                                                     signer: signer,
+                                                     key_password: "1234"
+    mail.deliver
+    common_message_expectations(mail)
+    pgp_signed_and_encrypted_part_expectations(mail, expected_signer: signer)
+    decrypted_mail = decrypt_mail(mail)
+    decrypted_part_expectations_for_simple_mail(decrypted_mail)
+  end
 end

--- a/spec/acceptance/rnp/sign_and_encrypt_encapsulated_spec.rb
+++ b/spec/acceptance/rnp/sign_and_encrypt_encapsulated_spec.rb
@@ -72,4 +72,19 @@ RSpec.describe "Signing and encrypting in encapsulated fashion with RNP" do
     pgp_signed_part_expectations(decrypted_mail, expected_signer: signer)
     decrypted_part_expectations_for_simple_mail(decrypted_mail.parts[0])
   end
+
+  specify "with a password-protected signer key" do
+    mail = simple_mail
+    signer = "cato.elder+pwd@example.test"
+
+    EnMail.protect :sign_and_encrypt_encapsulated, mail, adapter: adapter_class,
+                                                         signer: signer,
+                                                         key_password: "1234"
+    mail.deliver
+    common_message_expectations(mail)
+    pgp_encrypted_part_expectations(mail)
+    decrypted_mail = decrypt_mail(mail)
+    pgp_signed_part_expectations(decrypted_mail, expected_signer: signer)
+    decrypted_part_expectations_for_simple_mail(decrypted_mail.parts[0])
+  end
 end

--- a/spec/acceptance/rnp/sign_spec.rb
+++ b/spec/acceptance/rnp/sign_spec.rb
@@ -61,4 +61,16 @@ RSpec.describe "Signing with RNP" do
     pgp_signed_part_expectations(mail, expected_signer: signer)
     decrypted_part_expectations_for_simple_mail(mail.parts[0])
   end
+
+  specify "with a password-protected signer key" do
+    mail = simple_mail
+    signer = "cato.elder+pwd@example.test"
+
+    EnMail.protect :sign, mail, adapter: adapter_class, signer: signer,
+                                key_password: "1234"
+    mail.deliver
+    common_message_expectations(mail)
+    pgp_signed_part_expectations(mail, expected_signer: signer)
+    decrypted_part_expectations_for_simple_mail(mail.parts[0])
+  end
 end


### PR DESCRIPTION
Adds support for password-protected keys to GPGME adapter. Requires that Pinentry supports loopback mode, which is generally provided since GnuPG 2.1.

Fixes #76. Fixes #77.