### PR TITLE
Generally improve the be_a_valid_pgp_signature_of RSpec matcher

### DIFF
--- a/spec/matchers_spec.rb
+++ b/spec/matchers_spec.rb
@@ -1,6 +1,7 @@
 require "spec_helper"
 
 RSpec.describe :be_a_valid_pgp_signature_of do
+  subject { method(:be_a_valid_pgp_signature_of) }
   let(:failure_exception) { RSpec::Expectations::ExpectationNotMetError }
   let(:crypto) { ::GPGME::Crypto.new(armor: true, signer: signer) }
   let(:sig) { crypto.detach_sign(text).to_s }
@@ -9,26 +10,26 @@ RSpec.describe :be_a_valid_pgp_signature_of do
   let(:signer) { "whatever@example.test" }
 
   it "assures that string contains PGP data" do
-    m = be_a_valid_pgp_signature_of(text)
+    m = subject.(text)
     expect(m.matches?("a ")).to be(false)
   end
 
   it "assures that string is a valid signature of given text" do
-    m = be_a_valid_pgp_signature_of(text)
+    m = subject.(text)
     expect(m.matches?(sig)).to be(true)
 
-    m = be_a_valid_pgp_signature_of(misspelled)
+    m = subject.(misspelled)
     expect(m.matches?(sig)).to be(false)
   end
 
   it "assures that string is signed with correct key" do
-    m = be_a_valid_pgp_signature_of(text).signed_by(signer)
+    m = subject.(text).signed_by(signer)
     expect(m.matches?(sig)).to be(true)
 
-    m = be_a_valid_pgp_signature_of(text).signed_by("a@example.test")
+    m = subject.(text).signed_by("a@example.test")
     expect(m.matches?(sig)).to be(false)
 
-    m = be_a_valid_pgp_signature_of(misspelled).signed_by(signer)
+    m = subject.(misspelled).signed_by(signer)
     expect(m.matches?(sig)).to be(false)
   end
 end

--- a/spec/support/matchers/be_a_valid_pgp_signature_of.rb
+++ b/spec/support/matchers/be_a_valid_pgp_signature_of.rb
@@ -1,6 +1,6 @@
 RSpec::Matchers.define :be_a_valid_pgp_signature_of do |text|
-  match do |signature|
-    @err = parse_and_validate_signature(signature, text)
+  match do |signature_string|
+    @err = parse_and_validate_signature(signature_string, text)
     @err.nil?
   end
 
@@ -11,9 +11,9 @@ RSpec::Matchers.define :be_a_valid_pgp_signature_of do |text|
   end
 
   # Returns +nil+ if first signature is valid, or an error message otherwise.
-  def parse_and_validate_signature(signature, text)
+  def parse_and_validate_signature(signature_string, text)
     cleartext_data = GPGME::Data.new(text)
-    signature_data = GPGME::Data.new(signature)
+    signature_data = GPGME::Data.new(signature_string)
 
     GPGME::Ctx.new(armor: true) do |ctx|
       # That final +nil+ is obligatory
@@ -21,7 +21,7 @@ RSpec::Matchers.define :be_a_valid_pgp_signature_of do |text|
       match_signature(ctx.verify_result.signatures.first)
     end
   rescue GPGME::Error::NoData # Signature parse error
-    msg_no_gpg_sig(signature)
+    msg_no_gpg_sig(signature_string)
   end
 
   def match_signature(sig)

--- a/spec/support/matchers/be_a_valid_pgp_signature_of.rb
+++ b/spec/support/matchers/be_a_valid_pgp_signature_of.rb
@@ -1,13 +1,13 @@
 RSpec::Matchers.define :be_a_valid_pgp_signature_of do |text|
   match do |signature|
-    @msg = validate_signature(signature, text)
-    @msg.nil?
+    @err = validate_signature(signature, text)
+    @err.nil?
   end
 
   chain :signed_by, :expected_signer
 
   failure_message do
-    @msg
+    @err
   end
 
   # Returns +nil+ if first signature is valid, or an error message otherwise.

--- a/spec/support/matchers/be_a_valid_pgp_signature_of.rb
+++ b/spec/support/matchers/be_a_valid_pgp_signature_of.rb
@@ -1,4 +1,6 @@
 RSpec::Matchers.define :be_a_valid_pgp_signature_of do |text|
+  attr_reader :err
+
   match do |signature_string|
     @err = parse_and_validate_signature(signature_string, text)
     @err.nil?
@@ -7,7 +9,7 @@ RSpec::Matchers.define :be_a_valid_pgp_signature_of do |text|
   chain :signed_by, :expected_signer
 
   failure_message do
-    @err
+    err
   end
 
   # Returns +nil+ if first signature is valid, or an error message otherwise.


### PR DESCRIPTION
A set of various improvements for custom RSpec matchers used in this project:
– switch from high-level GPGME API to mid-level one
– make general code style improvements
– simplify tests

Improvements came from the experience gathered while working on matcher for encrypted messages on some development branch.