### PR TITLE
Sign and encrypt messages with GPGME, in a RFC 1847 encapsulation fashion

### DIFF
--- a/lib/enmail/adapters/gpgme.rb
+++ b/lib/enmail/adapters/gpgme.rb
@@ -38,6 +38,13 @@ module EnMail
         message.add_part encrypted_part
       end
 
+      # The RFC 3156 requires that the message is first signed, then encrypted.
+      # See: https://tools.ietf.org/html/rfc3156#section-6.1
+      def sign_and_encrypt_encapsulated(message)
+        sign(message)
+        encrypt(message)
+      end
+
       private
 
       # Returns a new +Mail::Part+ with the same content and MIME headers

--- a/spec/acceptance/gpgme/encrypt_and_sign_encapsulated_spec.rb
+++ b/spec/acceptance/gpgme/encrypt_and_sign_encapsulated_spec.rb
@@ -1,0 +1,55 @@
+require "spec_helper"
+
+RSpec.describe "Signing and encrypting in encapsulated fashion with GPGME" do
+  include_context "example emails"
+  include_context "expectations for example emails"
+  include_context "gpgme spec helpers"
+
+  specify "a non-multipart text-only message" do
+    mail = simple_mail
+
+    EnMail.protect :sign_and_encrypt_encapsulated, mail
+    mail.deliver
+    common_message_expectations(mail)
+    pgp_encrypted_part_expectations(mail)
+    decrypted_mail = decrypt_mail(mail)
+    pgp_signed_part_expectations(decrypted_mail)
+    decrypted_part_expectations_for_simple_mail(decrypted_mail.parts[0])
+  end
+
+  specify "a non-multipart HTML message" do
+    mail = simple_html_mail
+
+    EnMail.protect :sign_and_encrypt_encapsulated, mail
+    mail.deliver
+    common_message_expectations(mail)
+    pgp_encrypted_part_expectations(mail)
+    decrypted_mail = decrypt_mail(mail)
+    pgp_signed_part_expectations(decrypted_mail)
+    decrypted_part_expectations_for_simple_html_mail(decrypted_mail.parts[0])
+  end
+
+  specify "a multipart text+HTML message" do
+    mail = text_html_mail
+
+    EnMail.protect :sign_and_encrypt_encapsulated, mail
+    mail.deliver
+    common_message_expectations(mail)
+    pgp_encrypted_part_expectations(mail)
+    decrypted_mail = decrypt_mail(mail)
+    pgp_signed_part_expectations(decrypted_mail)
+    decrypted_part_expectations_for_text_html_mail(decrypted_mail.parts[0])
+  end
+
+  specify "a multipart message with binary attachments" do
+    mail = text_jpeg_mail
+
+    EnMail.protect :sign_and_encrypt_encapsulated, mail
+    mail.deliver
+    common_message_expectations(mail)
+    pgp_encrypted_part_expectations(mail)
+    decrypted_mail = decrypt_mail(mail)
+    pgp_signed_part_expectations(decrypted_mail)
+    decrypted_part_expectations_for_text_jpeg_mail(decrypted_mail.parts[0])
+  end
+end

--- a/spec/acceptance/gpgme/encrypt_spec.rb
+++ b/spec/acceptance/gpgme/encrypt_spec.rb
@@ -3,6 +3,7 @@ require "spec_helper"
 RSpec.describe "Encrypting with GPGME" do
   include_context "example emails"
   include_context "expectations for example emails"
+  include_context "gpgme spec helpers"
 
   specify "a non-multipart text-only message" do
     mail = simple_mail
@@ -42,11 +43,5 @@ RSpec.describe "Encrypting with GPGME" do
     common_message_expectations(mail)
     pgp_encrypted_part_expectations(mail)
     decrypted_part_expectations_for_text_jpeg_mail(decrypt_mail(mail))
-  end
-
-  def decrypt_mail(message)
-    encrypted_message = message.parts[1].body.decoded
-    decrypted_raw_message = GPGME::Crypto.new.decrypt(encrypted_message)
-    Mail::Part.new(decrypted_raw_message)
   end
 end

--- a/spec/acceptance/gpgme/encrypt_spec.rb
+++ b/spec/acceptance/gpgme/encrypt_spec.rb
@@ -2,6 +2,7 @@ require "spec_helper"
 
 RSpec.describe "Encrypting with GPGME" do
   include_context "example emails"
+  include_context "expectations for example emails"
 
   specify "a non-multipart text-only message" do
     mail = simple_mail
@@ -41,22 +42,6 @@ RSpec.describe "Encrypting with GPGME" do
     common_message_expectations(mail)
     pgp_encrypted_part_expectations(mail)
     decrypted_part_expectations_for_text_jpeg_mail(decrypt_mail(mail))
-  end
-
-  def pgp_encrypted_part_expectations(message_or_part)
-    expect(message_or_part.mime_type).to eq("multipart/encrypted")
-    expect(message_or_part.content_type_parameters).to include(
-      "protocol" => "application/pgp-encrypted",
-    )
-    expect(message_or_part.parts.size).to eq(2)
-    expect(message_or_part.parts[0].mime_type).
-      to eq("application/pgp-encrypted")
-    expect(message_or_part.parts[0].content_type_parameters).to be_empty
-    expect(message_or_part.parts[0].body.encoded).to eq("Version: 1")
-
-    expect(message_or_part.parts[1].body.decoded).
-      to be_a_pgp_encrypted_message.
-      encrypted_for(mail_to)
   end
 
   def decrypt_mail(message)

--- a/spec/acceptance/gpgme/sign_spec.rb
+++ b/spec/acceptance/gpgme/sign_spec.rb
@@ -2,6 +2,7 @@ require "spec_helper"
 
 RSpec.describe "Signing with GPGME" do
   include_context "example emails"
+  include_context "expectations for example emails"
 
   specify "a non-multipart text-only message" do
     mail = simple_mail
@@ -52,21 +53,5 @@ RSpec.describe "Signing with GPGME" do
     common_message_expectations(mail)
     pgp_signed_part_expectations(mail, expected_signer: signer)
     decrypted_part_expectations_for_simple_mail(mail.parts[0])
-  end
-
-  def pgp_signed_part_expectations(message_or_part, expected_signer: mail_from)
-    expect(message_or_part.mime_type).to eq("multipart/signed")
-    expect(message_or_part.content_type_parameters).to include(
-      "micalg" => "pgp-sha1",
-      "protocol" => "application/pgp-signature",
-    )
-    expect(message_or_part.parts.size).to eq(2)
-    expect(message_or_part.parts[1].mime_type).
-      to eq("application/pgp-signature")
-    expect(message_or_part.parts[1].content_type_parameters).to be_empty
-
-    expect(message_or_part.parts[1].body.decoded).
-      to be_a_valid_pgp_signature_of(message_or_part.parts[0].encoded).
-      signed_by(expected_signer)
   end
 end

--- a/spec/acceptance/without_enmail_spec.rb
+++ b/spec/acceptance/without_enmail_spec.rb
@@ -2,6 +2,7 @@ require "spec_helper"
 
 RSpec.describe "Sending without protection (unaltered by EnMail)" do
   include_context "example emails"
+  include_context "expectations for example emails"
 
   specify "a non-multipart text-only message" do
     mail = simple_mail

--- a/spec/support/example_emails.rb
+++ b/spec/support/example_emails.rb
@@ -15,11 +15,6 @@ shared_context "example emails" do
     m
   end
 
-  def decrypted_part_expectations_for_simple_mail(message_or_part)
-    expect(message_or_part.mime_type).to eq("text/plain")
-    expect(message_or_part.body.decoded).to eq(mail_text)
-  end
-
   let(:simple_html_mail) do
     m = Mail.new
     m.from = mail_from
@@ -29,11 +24,6 @@ shared_context "example emails" do
     m.body = mail_html
     m.content_type = "text/html"
     m
-  end
-
-  def decrypted_part_expectations_for_simple_html_mail(message_or_part)
-    expect(message_or_part.mime_type).to eq("text/html")
-    expect(message_or_part.body.decoded).to eq(mail_html)
   end
 
   let(:text_html_mail) do
@@ -47,13 +37,6 @@ shared_context "example emails" do
     m
   end
 
-  def decrypted_part_expectations_for_text_html_mail(message_or_part)
-    expect(message_or_part.parts[0].mime_type).to eq("text/plain")
-    expect(message_or_part.parts[0].body.decoded).to eq(mail_text)
-    expect(message_or_part.parts[1].mime_type).to eq("text/html")
-    expect(message_or_part.parts[1].body.decoded).to eq(mail_html)
-  end
-
   let(:text_jpeg_mail) do
     m = Mail.new
     m.from = mail_from
@@ -63,18 +46,5 @@ shared_context "example emails" do
     m.body = mail_text
     m.add_file filename: "pic.jpg", content: SMALLEST_JPEG
     m
-  end
-
-  def decrypted_part_expectations_for_text_jpeg_mail(message_or_part)
-    expect(message_or_part.parts[0].mime_type).to eq("text/plain")
-    expect(message_or_part.parts[0].body.decoded).to eq(mail_text)
-    expect(message_or_part.parts[1].mime_type).to eq("image/jpeg")
-    expect(message_or_part.parts[1].body.decoded).to eq(SMALLEST_JPEG)
-  end
-
-  def common_message_expectations(message)
-    expect(message.from).to contain_exactly(mail_from)
-    expect(message.to).to contain_exactly(mail_to)
-    expect(message.subject).to eq(mail_subject)
   end
 end

--- a/spec/support/expectations_for_example_emails.rb
+++ b/spec/support/expectations_for_example_emails.rb
@@ -1,0 +1,63 @@
+shared_context "expectations for example emails" do
+  def decrypted_part_expectations_for_simple_mail(message_or_part)
+    expect(message_or_part.mime_type).to eq("text/plain")
+    expect(message_or_part.body.decoded).to eq(mail_text)
+  end
+
+  def decrypted_part_expectations_for_simple_html_mail(message_or_part)
+    expect(message_or_part.mime_type).to eq("text/html")
+    expect(message_or_part.body.decoded).to eq(mail_html)
+  end
+
+  def decrypted_part_expectations_for_text_html_mail(message_or_part)
+    expect(message_or_part.parts[0].mime_type).to eq("text/plain")
+    expect(message_or_part.parts[0].body.decoded).to eq(mail_text)
+    expect(message_or_part.parts[1].mime_type).to eq("text/html")
+    expect(message_or_part.parts[1].body.decoded).to eq(mail_html)
+  end
+
+  def decrypted_part_expectations_for_text_jpeg_mail(message_or_part)
+    expect(message_or_part.parts[0].mime_type).to eq("text/plain")
+    expect(message_or_part.parts[0].body.decoded).to eq(mail_text)
+    expect(message_or_part.parts[1].mime_type).to eq("image/jpeg")
+    expect(message_or_part.parts[1].body.decoded).to eq(SMALLEST_JPEG)
+  end
+
+  def common_message_expectations(message)
+    expect(message.from).to contain_exactly(mail_from)
+    expect(message.to).to contain_exactly(mail_to)
+    expect(message.subject).to eq(mail_subject)
+  end
+
+  def pgp_signed_part_expectations(message_or_part, expected_signer: mail_from)
+    expect(message_or_part.mime_type).to eq("multipart/signed")
+    expect(message_or_part.content_type_parameters).to include(
+      "micalg" => "pgp-sha1",
+      "protocol" => "application/pgp-signature",
+    )
+    expect(message_or_part.parts.size).to eq(2)
+    expect(message_or_part.parts[1].mime_type).
+      to eq("application/pgp-signature")
+    expect(message_or_part.parts[1].content_type_parameters).to be_empty
+
+    expect(message_or_part.parts[1].body.decoded).
+      to be_a_valid_pgp_signature_of(message_or_part.parts[0].encoded).
+      signed_by(expected_signer)
+  end
+
+  def pgp_encrypted_part_expectations(message_or_part)
+    expect(message_or_part.mime_type).to eq("multipart/encrypted")
+    expect(message_or_part.content_type_parameters).to include(
+      "protocol" => "application/pgp-encrypted",
+    )
+    expect(message_or_part.parts.size).to eq(2)
+    expect(message_or_part.parts[0].mime_type).
+      to eq("application/pgp-encrypted")
+    expect(message_or_part.parts[0].content_type_parameters).to be_empty
+    expect(message_or_part.parts[0].body.encoded).to eq("Version: 1")
+
+    expect(message_or_part.parts[1].body.decoded).
+      to be_a_pgp_encrypted_message.
+      encrypted_for(mail_to)
+  end
+end

--- a/spec/support/gpgme_spec_helpers.rb
+++ b/spec/support/gpgme_spec_helpers.rb
@@ -1,0 +1,7 @@
+shared_context "gpgme spec helpers" do
+  def decrypt_mail(message)
+    encrypted_message = message.parts[1].body.decoded
+    decrypted_raw_message = GPGME::Crypto.new.decrypt(encrypted_message)
+    Mail::Part.new(decrypted_raw_message)
+  end
+end


### PR DESCRIPTION
Signing then encrypting messages is a better idea than encrypting then signing, though it has its security limitations as well, see http://world.std.com/~dtd/sign_encrypt/sign_encrypt7.html for details. Also, the RFC 3156 "MIME Security with OpenPGP" encourages to sign then encrypt messages, without even mentioning a reverse order.

Hence, it is a good idea to provide a simple method which does both things in correct order, rather than to rely on the gem users' awareness.
