### PR TITLE
Test against compatible GnuPG versions

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -13,3 +13,9 @@ indent_style = space
 indent_size = 2
 insert_final_newline = true
 trim_trailing_whitespace = true
+
+[*.sh]
+indent_style = tab
+indent_size = 4
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ rvm:
 
 env:
   global:
+    - EXPECT_GPG_VERSION="2.2"
     - GPG_VERSION="latest"
     - GPG_BUILD_DIR="$TRAVIS_BUILD_DIR/build_gpg"
     - >

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 dist: trusty
-sudo: false
+sudo: required
 language: ruby
 
 rvm:
@@ -8,7 +8,18 @@ rvm:
   - 2.3
   - ruby-head
 
+env:
+  global:
+    - GPG_VERSION="latest"
+    - GPG_BUILD_DIR="$TRAVIS_BUILD_DIR/build_gpg"
+    - >
+      GPG_CONFIGURE_OPTS="--disable-doc --enable-pinentry-curses
+      --disable-pinentry-emacs --disable-pinentry-gtk2 --disable-pinentry-gnome3
+      --disable-pinentry-qt --disable-pinentry-qt4 --disable-pinentry-qt5
+      --disable-pinentry-tqt --disable-pinentry-fltk"
+
 before_install:
+  - ./install_gpg_all.sh "$GPG_VERSION" --build-dir "$GPG_BUILD_DIR" --configure-opts "$GPG_CONFIGURE_OPTS" --folding-style travis
   - gem install bundler -v 1.16.1
 
 before_script:

--- a/install_gpg_all.sh
+++ b/install_gpg_all.sh
@@ -1,0 +1,137 @@
+#!/bin/bash
+
+# Popular combinations of GPG software versions.
+#
+# For v2.2: https://gist.github.com/vt0r/a2f8c0bcb1400131ff51
+# For v2.1: https://gist.github.com/mattrude/3883a3801613b048d45b
+#
+# USAGE:
+#   ./install_gpg_all.sh <version> [<options>]
+#
+# EXAMPLE
+#   ./install_gpg_all.sh 2.2
+
+set -e
+
+readonly __progname=$(basename $0)
+
+errx() {
+	echo -e "$__progname: $@" >&2
+	exit 1
+}
+
+usage() {
+	echo "usage: $__progname [-t <TEMP_BUILD_DIR>] [-i <GPG_VERSION>] [-d]"
+	echo ""
+	echo "  Options:"
+	echo "  -d for dry run, not building GPG components."
+	echo "  -i to select the GPG version to install [major.minor], defaults to `latest`."
+	echo "      - `latest`: latest version of GnuPG."
+	echo "      - `x.y`: specific version x.y of GnuPG, e.g. `2.2`."
+	echo "      - `master`: build from GnuPG git master branch."
+	echo "  -h to display this message"
+	echo ""
+	echo "  Arguments can also be set via environment variables: "
+	echo "  - TEMP_BUILD_DIR"
+	echo "  - GPG_VERSION"
+	exit 1
+}
+
+prequisites_yum() {
+	yum install -y bzip2 gcc make sudo
+}
+
+detect_platform() {
+	# Determine OS platform
+	DISTRO=$(awk -F= '/^NAME/{print $2}' /etc/os-release | tr -d \")
+	echo "$DISTRO"
+}
+
+main() {
+
+	while getopts ":t:idh" o; do
+		case "${o}" in
+		t)
+			readonly local TEMP_BUILD_DIR=1
+			;;
+		i)
+			readonly local GPG_VERSION=${OPTARG}
+			;;
+		d)
+			readonly local DRYRUN=1
+			;;
+		h)
+			usage
+			;;
+		*)
+			usage
+			;;
+		esac
+	done
+
+	if [ "x$GPG_VERSION" == "x" ]; then
+		GPG_VERSION="latest"
+	fi
+
+	[[ ! "$TEMP_BUILD_DIR" ]] && \
+		TEMP_BUILD_DIR="$(mktemp -d)"
+
+	DISTRO="$(detect_platform)"
+
+	case $DISTRO in
+		"CentOS Linux")
+			echo "Installing CentOS yum dependencies"
+			prequisites_yum
+			;;
+	esac
+
+	case "$GPG_VERSION" in
+		"2.2")
+			./install_gpg_component.sh --component libgpg-error --version 1.31 --build-dir "$TEMP_BUILD_DIR" "${@:2}"
+			./install_gpg_component.sh --component libgcrypt --version 1.8.2 --build-dir "$TEMP_BUILD_DIR" "${@:2}"
+			./install_gpg_component.sh --component libassuan --version 2.5.1 --build-dir "$TEMP_BUILD_DIR" "${@:2}"
+			./install_gpg_component.sh --component libksba --version 1.3.5 --build-dir "$TEMP_BUILD_DIR" "${@:2}"
+			./install_gpg_component.sh --component npth --version 1.5 --build-dir "$TEMP_BUILD_DIR" "${@:2}"
+			./install_gpg_component.sh --component pinentry --version 1.1.0 --build-dir "$TEMP_BUILD_DIR" "${@:2}"
+			./install_gpg_component.sh --component gnupg --version 2.2.7 --build-dir "$TEMP_BUILD_DIR" "${@:2}"
+			;;
+		"2.1")
+			./install_gpg_component.sh --component libgpg-error --version 1.27 --build-dir "$TEMP_BUILD_DIR" "${@:2}"
+			./install_gpg_component.sh --component libgcrypt --version 1.7.6 --build-dir "$TEMP_BUILD_DIR" "${@:2}"
+			./install_gpg_component.sh --component libassuan --version 2.4.3 --build-dir "$TEMP_BUILD_DIR" "${@:2}"
+			./install_gpg_component.sh --component libksba --version 1.3.5 --build-dir "$TEMP_BUILD_DIR" "${@:2}"
+			./install_gpg_component.sh --component npth --version 1.2 --build-dir "$TEMP_BUILD_DIR" "${@:2}"
+			./install_gpg_component.sh --component pinentry --version 0.9.5 --build-dir "$TEMP_BUILD_DIR" "${@:2}"
+			./install_gpg_component.sh --component gnupg --version 2.1.20 --build-dir "$TEMP_BUILD_DIR" "${@:2}"
+			;;
+		"latest")
+			./install_gpg_component.sh --component libgpg-error --version latest --build-dir "$TEMP_BUILD_DIR" "${@:2}"
+			./install_gpg_component.sh --component libgcrypt --version latest --build-dir "$TEMP_BUILD_DIR" "${@:2}"
+			./install_gpg_component.sh --component libassuan --version latest --build-dir "$TEMP_BUILD_DIR" "${@:2}"
+			./install_gpg_component.sh --component libksba --version latest --build-dir "$TEMP_BUILD_DIR" "${@:2}"
+			./install_gpg_component.sh --component npth --version latest --build-dir "$TEMP_BUILD_DIR" "${@:2}"
+			./install_gpg_component.sh --component pinentry --version latest --build-dir "$TEMP_BUILD_DIR" "${@:2}"
+			./install_gpg_component.sh --component gnupg --version latest --build-dir "$TEMP_BUILD_DIR" "${@:2}"
+			;;
+		"master")
+			./install_gpg_component.sh --component libgpg-error --version master --git --build-dir "$TEMP_BUILD_DIR" "${@:2}"
+			./install_gpg_component.sh --component libgcrypt --version master --git --build-dir "$TEMP_BUILD_DIR" "${@:2}"
+			./install_gpg_component.sh --component libassuan --version master --git --build-dir "$TEMP_BUILD_DIR" "${@:2}"
+			./install_gpg_component.sh --component libksba --version master --git --build-dir "$TEMP_BUILD_DIR" "${@:2}"
+			./install_gpg_component.sh --component npth --version master --git --build-dir "$TEMP_BUILD_DIR" "${@:2}"
+			./install_gpg_component.sh --component pinentry --version master --git --build-dir "$TEMP_BUILD_DIR" "${@:2}"
+			./install_gpg_component.sh --component gnupg --version master --git --build-dir "$TEMP_BUILD_DIR" "${@:2}"
+			;;
+	esac
+
+	cat <<DONE
++-------------------+
+| INSTALL COMPLETE! |
++-------------------+
+DONE
+
+}
+
+main "$@"
+
+exit 0

--- a/install_gpg_component.sh
+++ b/install_gpg_component.sh
@@ -1,0 +1,301 @@
+#!/usr/bin/env bash
+#
+
+######################
+# ARGUMENTS HANDLING #
+######################
+
+print_help ()
+{
+	cat <<HELP
+USAGE
+
+	install_gpg_component.rb <options>
+
+EXAMPLES
+
+	# Installing latest version of libgpg-error
+	install_gpg_component.rb --component libgpg-error --version latest
+
+	# Installing latest version of libgpg-error with sudo
+	install_gpg_component.rb --component libgpg-error --version latest --sudo
+
+	# Installing latest git revision of libgpg-error
+	install_gpg_component.rb --component libgpg-error --version master --git
+
+	# Passing options to ./configure script
+	install_gpg_component.rb --component libgpg-error --version latest --configure-opts "--disable-doc --exec-prefix=/my/bin"
+
+OPTIONS
+
+	--component COMPONENT
+		Component to install
+
+	--version VERSION
+		Component version to install (use "latest" for the latest release),
+		or git ref (branch, tag, commit hash etc.) when used with "--git"
+		option (typically "master").
+
+	--[no-]git
+		Fetch source code from git repository instead of downloading release,
+		pass branch or tag name to --version argument.  By default it is off.
+
+	--[no-]sudo
+		Whether to do 'sudo make install', or just 'make install'.
+		Doesn't affect post install steps, which may require sudo.  By default
+		it is off.
+
+	--configure-opts OPTS
+		Options to be passed to "./configure" script.
+
+	--build-dir DIR
+		Directory in which the compilation will happen.  Content may be
+		overwritten during build.  Directory will be created if non-existent.
+
+	--folding-style STYLE
+		If set, enables output folding.  STYLE defines the folding notation
+		used.  Following STYLE values are recognized:
+
+		"none"
+			Disable folding.  This is default.
+
+		"travis"
+			Fold output for Travis CI builds.  See this example Travis job:
+			https://api.travis-ci.org/v3/job/15440998/log.txt
+
+	--help, -h
+		Displays this message
+
+HELP
+}
+
+set_default_options()
+{
+	_arg_build_dir=
+	_arg_configure_opts=
+	_arg_sudo="off"
+	_arg_git="off"
+	_arg_color="off"
+	_arg_folding_style="none"
+}
+
+parse_cli_arguments()
+{
+	while test $# -gt 0
+	do
+		case "$1" in
+			--component)
+				_arg_component="$2"
+				shift
+				shift
+				;;
+			--version)
+				_arg_version="$2"
+				shift
+				shift
+				;;
+			--build-dir)
+				_arg_build_dir="$2"
+				shift
+				shift
+				;;
+			--configure-opts)
+				_arg_configure_opts="$2"
+				shift
+				shift
+				;;
+			--sudo)
+				_arg_sudo="on"
+				shift
+				;;
+			--no-sudo)
+				_arg_sudo="off"
+				shift
+				;;
+			--git)
+				_arg_git="on"
+				shift
+				;;
+			--no-git)
+				_arg_git="off"
+				shift
+				;;
+			--folding-style)
+				_arg_folding_style="$2"
+				shift
+				shift
+				;;
+			-h|--help)
+				print_help
+				exit 0
+				;;
+			*)
+				echo "Unrecognized option: $1, exiting."
+				exit 1
+		esac
+	done
+}
+
+######################
+#      BUILDING      #
+######################
+
+display_config()
+{
+	cat <<CONFIG
+component: "${_arg_component}"
+version: "${_arg_version}"
+git: "${_arg_git}"
+sudo: "${_arg_sudo}"
+build_dir: "${_arg_build_dir}"
+configure_options: "${_arg_configure_opts}"
+
+CONFIG
+}
+
+# Consults https://versions.gnupg.org/swdb.lst and assigns the most recent
+# version of component ${_arg_component} to ${_arg_version} variable.
+determine_latest_version()
+{
+	fold_start "component.${_arg_component}.detect-latest"
+	local _component_underscored=`echo "${_arg_component}" | tr - _`
+	_arg_version=`curl "https://versions.gnupg.org/swdb.lst" | grep "_ver" | grep -v "w32" | sort --reverse | grep "${_component_underscored}" | head -n 1 | cut -d " " -f 2`
+	echo "The latest version of ${_arg_component} is ${_arg_version}."
+	fold_end "component.${_arg_component}.fetch"
+}
+
+fetch_source()
+{
+	fold_start "component.${_arg_component}.fetch"
+	if [[ "${_arg_git}" = "on" ]]; then
+		fetch_from_git
+	else
+		fetch_release
+	fi
+	fold_end "component.${_arg_component}.fetch"
+}
+
+fetch_release()
+{
+	local _tarball_file_name="${_arg_component}-${_arg_version}.tar.bz2"
+	local _tarball_url="https://gnupg.org/ftp/gcrypt/${_arg_component}/${_tarball_file_name}"
+	curl ${_tarball_url} --remote-name --retry 5
+	tar -xjf ${_tarball_file_name}
+	rm ${_tarball_file_name}
+	set_component_build_dir "${_arg_component}-${_arg_version}"
+}
+
+fetch_from_git()
+{
+	local _git_url="git://git.gnupg.org/${_arg_component}"
+	set_component_build_dir "${_arg_component}-git-${_arg_version}"
+
+	if [ ! -d "${_component_build_dir}" ]; then
+		git clone ${_git_url} "${_component_build_dir}"
+	else
+		pushd "${_component_build_dir}"
+		git fetch # need to fetch prior checkout, ref may be nonexistent locally
+		popd
+	fi
+
+	pushd "${_component_build_dir}"
+	git checkout ${_arg_version}
+	git pull # in case of outdated local branch
+	popd
+}
+
+build_and_install()
+{
+	pushd "${_component_build_dir}"
+	if [ ! -f configure ]; then
+		fold_start "component.${_arg_component}.autogen"
+		./autogen.sh
+		fold_end "component.${_arg_component}.autogen"
+	fi
+	fold_start "component.${_arg_component}.configure"
+	./configure ${_arg_configure_opts}
+	fold_end "component.${_arg_component}.configure"
+	fold_start "component.${_arg_component}.build"
+	make > /dev/null
+	fold_end "component.${_arg_component}.build"
+	fold_start "component.${_arg_component}.install"
+	sudo make install > /dev/null
+	fold_end "component.${_arg_component}.install"
+	popd
+}
+
+set_component_build_dir()
+{
+	_component_build_dir=$1
+}
+
+header()
+{
+	echo ""
+	echo ""
+	echo "=== $1 ==="
+	echo ""
+	echo ""
+}
+
+######################
+#    PRETTY OUTPUT   #
+######################
+
+fold_start()
+{
+	case "${_arg_folding_style}" in
+		travis)
+			echo "travis_fold:start:$1"
+			;;
+		*)
+			;;
+	esac
+}
+
+fold_end()
+{
+	case "${_arg_folding_style}" in
+		travis)
+			echo "travis_fold:end:$1"
+			;;
+		*)
+			;;
+	esac
+}
+
+######################
+#        MAIN        #
+######################
+
+set -e # Early exit if any command returns non-zero status code
+
+set_default_options
+parse_cli_arguments "$@"
+
+fold_start "component.${_arg_component}"
+
+header "Installing ${_arg_component} / ${_arg_version}"
+
+display_config
+
+# set -x # From now, print every command to STDOUT
+
+if [[ "${_arg_version}" =~ ^latest ]]; then
+	determine_latest_version
+fi
+
+mkdir -p ${_arg_build_dir}
+pushd ${_arg_build_dir}
+fetch_source
+build_and_install
+popd # _arg_build_dir
+
+if [[ "${_arg_component}" =~ ^gnupg ]]; then
+	fold_start "component.${_arg_component}.post-install"
+	sudo tee -a /etc/ld.so.conf.d/gpg2.conf <<<"/usr/local/lib"
+	sudo ldconfig -v
+	fold_end "component.${_arg_component}.post-install"
+fi
+
+fold_end "component.${_arg_component}"

--- a/spec/support/expect_correct_gpg_version.rb
+++ b/spec/support/expect_correct_gpg_version.rb
@@ -1,0 +1,18 @@
+expected_gpg_version = ENV.fetch("EXPECT_GPG_VERSION", nil)
+
+if expected_gpg_version
+  gpg_version_info = ::GPGME::Engine.info.detect do |ei|
+    %r"/bin/gpg\d*\Z" =~ ei.file_name
+  end
+
+  actual_gpg_version = gpg_version_info.version
+  expected_gpg_version_rx = /\A#{Regexp.escape(expected_gpg_version)}(\.|\Z)/
+
+  if expected_gpg_version_rx =~ actual_gpg_version
+    puts "This test suite is run against GPG version #{actual_gpg_version}."
+  else
+    raise "This test suite was expected to run with GPG version " +
+      "#{expected_gpg_version}, but was attempted to run with GPG version " +
+      "#{actual_gpg_version}.  Aborting!"
+  end
+end


### PR DESCRIPTION
Test against GPG version 2.1, and version 2.2. The EnMail won't work with GPG version 2.0, which is available by default in Ubuntu Trusty.