### PR TITLE
Separate concerns

### DIFF
--- a/lib/enmail/helpers/rfc1847.rb
+++ b/lib/enmail/helpers/rfc1847.rb
@@ -6,22 +6,6 @@ module EnMail
     module RFC1847
       include MessageManipulation
 
-      # Signs a message in a +multipart/signed+ fashion as defined in RFC 1847.
-      #
-      # @param [Mail::Message] message
-      #   Message which is expected to be signed.
-      def sign(message)
-        part_to_be_signed = body_to_part(message)
-        signer = find_signer_for(message)
-        signature_part = build_signature_part(part_to_be_signed, signer)
-
-        rewrite_body(
-          message,
-          content_type: multipart_signed_content_type,
-          parts: [part_to_be_signed, signature_part],
-        )
-      end
-
       # Encrypts a message in a +multipart/encrypted+ fashion as defined
       # in RFC 1847.
       #
@@ -37,6 +21,22 @@ module EnMail
           message,
           content_type: multipart_encrypted_content_type,
           parts: [control_part, encrypted_part],
+        )
+      end
+
+      # Signs a message in a +multipart/signed+ fashion as defined in RFC 1847.
+      #
+      # @param [Mail::Message] message
+      #   Message which is expected to be signed.
+      def sign(message)
+        part_to_be_signed = body_to_part(message)
+        signer = find_signer_for(message)
+        signature_part = build_signature_part(part_to_be_signed, signer)
+
+        rewrite_body(
+          message,
+          content_type: multipart_signed_content_type,
+          parts: [part_to_be_signed, signature_part],
         )
       end
 

--- a/lib/enmail/helpers/rfc1847.rb
+++ b/lib/enmail/helpers/rfc1847.rb
@@ -14,7 +14,8 @@ module EnMail
       def encrypt(message)
         part_to_be_encrypted = body_to_part(message)
         recipients = find_recipients_for(message)
-        encrypted_part = build_encrypted_part(part_to_be_encrypted, recipients)
+        encrypted = encrypt_string(part_to_be_encrypted.encoded, recipients).to_s
+        encrypted_part = build_encrypted_part(encrypted)
         control_part = build_encryption_control_part
 
         rewrite_body(
@@ -31,7 +32,8 @@ module EnMail
       def sign(message)
         part_to_be_signed = body_to_part(message)
         signer = find_signer_for(message)
-        signature_part = build_signature_part(part_to_be_signed, signer)
+        signature = compute_signature(part_to_be_signed.encoded, signer).to_s
+        signature_part = build_signature_part(signature)
 
         rewrite_body(
           message,
@@ -44,8 +46,7 @@ module EnMail
 
       # Builds a mail part containing the encrypted message, that is
       # the 2nd subpart of +multipart/encrypted+ as defined in RFC 1847.
-      def build_encrypted_part(part_to_encrypt, recipients)
-        encrypted = encrypt_string(part_to_encrypt.encoded, recipients).to_s
+      def build_encrypted_part(encrypted)
         part = ::Mail::Part.new
         part.content_type = encrypted_message_content_type
         part.body = encrypted
@@ -64,8 +65,7 @@ module EnMail
 
       # Builds a mail part containing the digital signature, that is
       # the 2nd subpart of +multipart/signed+ as defined in RFC 1847.
-      def build_signature_part(part_to_sign, signer)
-        signature = compute_signature(part_to_sign.encoded, signer).to_s
+      def build_signature_part(signature)
         part = ::Mail::Part.new
         part.content_type = sign_protocol
         part.body = signature

--- a/lib/enmail/helpers/rfc1847.rb
+++ b/lib/enmail/helpers/rfc1847.rb
@@ -12,9 +12,9 @@ module EnMail
       # @param [Mail::Message] message
       #   Message which is expected to be encrypted.
       def encrypt(message)
-        part_to_be_encrypted = body_to_part(message)
+        source_part = body_to_part(message)
         recipients = find_recipients_for(message)
-        encrypted = encrypt_string(part_to_be_encrypted.encoded, recipients).to_s
+        encrypted = encrypt_string(source_part.encoded, recipients).to_s
         encrypted_part = build_encrypted_part(encrypted)
         control_part = build_encryption_control_part
 
@@ -30,15 +30,15 @@ module EnMail
       # @param [Mail::Message] message
       #   Message which is expected to be signed.
       def sign(message)
-        part_to_be_signed = body_to_part(message)
+        source_part = body_to_part(message)
         signer = find_signer_for(message)
-        signature = compute_signature(part_to_be_signed.encoded, signer).to_s
+        signature = compute_signature(source_part.encoded, signer).to_s
         signature_part = build_signature_part(signature)
 
         rewrite_body(
           message,
           content_type: multipart_signed_content_type,
-          parts: [part_to_be_signed, signature_part],
+          parts: [source_part, signature_part],
         )
       end
 


### PR DESCRIPTION
Methods `#build_encrypted_part`, and `#build_signature_part` should not be responsible for any cryptographic duties.  They should build mail parts, that's all.

A side effect is that these methods will be easier to reuse when other cryptographic methods will be implemented.