### PR TITLE
Write missing specs

### DIFF
--- a/spec/unit/adapters/gpgme_spec.rb
+++ b/spec/unit/adapters/gpgme_spec.rb
@@ -6,6 +6,17 @@ RSpec.describe EnMail::Adapters::GPGME do
 
   include_context "example emails"
 
+  describe "#compute_signature" do
+    subject { adapter.method(:compute_signature) }
+    let(:text) { "Some Text." }
+    let(:signer) { "cato.elder@example.test" }
+
+    it "computes a detached signature for given text signed by given user" do
+      retval = subject.(text, signer)
+      expect(retval).to be_a_valid_pgp_signature_of(text).signed_by(signer)
+    end
+  end
+
   describe "#encrypt_string" do
     subject { adapter.method(:encrypt_string) }
     let(:text) { "Some Text." }

--- a/spec/unit/helpers/rfc3156_spec.rb
+++ b/spec/unit/helpers/rfc3156_spec.rb
@@ -5,4 +5,16 @@ RSpec.describe EnMail::Helpers::RFC3156 do
   let(:options) { {} }
 
   include_context "example emails"
+
+  describe "#sign_and_encrypt_encapsulated" do
+    subject { adapter.method(:sign_and_encrypt_encapsulated) }
+
+    let(:mail) { simple_mail }
+
+    it "signs and encrypts the message, in that exact order" do
+      expect(adapter).to receive(:sign).with(mail).ordered
+      expect(adapter).to receive(:encrypt).with(mail).ordered
+      subject.(mail)
+    end
+  end
 end


### PR DESCRIPTION
A couple of methods was missing unit tests. This is fixed now.