### PR TITLE
Sign and encrypt messages with GPGME, in a combined fashion

### DIFF
--- a/lib/enmail/adapters/gpgme.rb
+++ b/lib/enmail/adapters/gpgme.rb
@@ -23,6 +23,15 @@ module EnMail
         build_crypto.encrypt(text, recipients: recipients)
       end
 
+      def sign_and_encrypt_string(text, signer, recipients)
+        build_crypto.encrypt(
+          text,
+          sign: true,
+          signers: [signer],
+          recipients: recipients,
+        )
+      end
+
       def build_crypto
         ::GPGME::Crypto.new(armor: true)
       end

--- a/lib/enmail/helpers/rfc3156.rb
+++ b/lib/enmail/helpers/rfc3156.rb
@@ -6,6 +6,28 @@ module EnMail
     #
     # See: https://tools.ietf.org/html/rfc3156
     module RFC3156
+      # The RFC 3156 explicitly allows for signing and encrypting data in
+      # a single OpenPGP message.
+      # See: https://tools.ietf.org/html/rfc3156#section-6.2
+      #
+      # rubocop:disable Metrics/MethodLength
+      def sign_and_encrypt_combined(message)
+        source_part = body_to_part(message)
+        signer = find_signer_for(message)
+        recipients = find_recipients_for(message)
+        encrypted =
+          sign_and_encrypt_string(source_part.encoded, signer, recipients).to_s
+        encrypted_part = build_encrypted_part(encrypted)
+        control_part = build_encryption_control_part
+
+        rewrite_body(
+          message,
+          content_type: multipart_encrypted_content_type,
+          parts: [control_part, encrypted_part],
+        )
+      end
+      # rubocop:enable Metrics/MethodLength
+
       # The RFC 3156 requires that the message is first signed, then encrypted.
       # See: https://tools.ietf.org/html/rfc3156#section-6.1
       def sign_and_encrypt_encapsulated(message)

--- a/spec/acceptance/gpgme/sign_and_encrypt_combined_spec.rb
+++ b/spec/acceptance/gpgme/sign_and_encrypt_combined_spec.rb
@@ -1,0 +1,51 @@
+require "spec_helper"
+
+RSpec.describe "Signing and encrypting in combined fashion with GPGME" do
+  include_context "example emails"
+  include_context "expectations for example emails"
+  include_context "gpgme spec helpers"
+
+  specify "a non-multipart text-only message" do
+    mail = simple_mail
+
+    EnMail.protect :sign_and_encrypt_combined, mail
+    mail.deliver
+    common_message_expectations(mail)
+    pgp_signed_and_encrypted_part_expectations(mail)
+    decrypted_mail = decrypt_mail(mail)
+    decrypted_part_expectations_for_simple_mail(decrypted_mail)
+  end
+
+  specify "a non-multipart HTML message" do
+    mail = simple_html_mail
+
+    EnMail.protect :sign_and_encrypt_combined, mail
+    mail.deliver
+    common_message_expectations(mail)
+    pgp_signed_and_encrypted_part_expectations(mail)
+    decrypted_mail = decrypt_mail(mail)
+    decrypted_part_expectations_for_simple_html_mail(decrypted_mail)
+  end
+
+  specify "a multipart text+HTML message" do
+    mail = text_html_mail
+
+    EnMail.protect :sign_and_encrypt_combined, mail
+    mail.deliver
+    common_message_expectations(mail)
+    pgp_signed_and_encrypted_part_expectations(mail)
+    decrypted_mail = decrypt_mail(mail)
+    decrypted_part_expectations_for_text_html_mail(decrypted_mail)
+  end
+
+  specify "a multipart message with binary attachments" do
+    mail = text_jpeg_mail
+
+    EnMail.protect :sign_and_encrypt_combined, mail
+    mail.deliver
+    common_message_expectations(mail)
+    pgp_signed_and_encrypted_part_expectations(mail)
+    decrypted_mail = decrypt_mail(mail)
+    decrypted_part_expectations_for_text_jpeg_mail(decrypted_mail)
+  end
+end

--- a/spec/support/expectations_for_example_emails.rb
+++ b/spec/support/expectations_for_example_emails.rb
@@ -68,5 +68,16 @@ shared_context "expectations for example emails" do
       to be_a_pgp_encrypted_message.
       encrypted_for(mail_to)
   end
+
+  def pgp_signed_and_encrypted_part_expectations(message_or_part,
+    expected_signer: mail_from)
+    # General encrypted message expectations do apply as it is generally
+    # an encrypted message, it just has some signatures added.
+    pgp_encrypted_part_expectations(message_or_part)
+
+    expect(message_or_part.parts[1].body.decoded).
+      to be_a_pgp_encrypted_message.
+      signed_by(expected_signer)
+  end
 end
 # rubocop:enable Metrics/AbcSize


### PR DESCRIPTION
The RFC 3156 explicitly allows for signing and encrypting data in a single OpenPGP message.

A style guide offence in a RSpec matcher seems to be out of the scope of this pull request. Both Open-PGP-related matchers need to be refactored, and perhaps they should share some of their logic.