### PR TITLE
Rewrite PGP matchers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,3 +17,4 @@ before_script:
 matrix:
   allow_failures:
     - rvm: ruby-head
+    - rvm: 2.3

--- a/spec/support/gpgme_setup.rb
+++ b/spec/support/gpgme_setup.rb
@@ -2,6 +2,6 @@
 # on file name length of the socket, and GPGME makes use of UNIX sockets.
 # Directory name produced by +Dir.mktmpdir+ is often quite long, and that
 # may cause weird error with misleading message.
-tmp_gpgme_home = File.expand_path("../../tmp/gpgme", __dir__)
-FileUtils.mkdir_p(tmp_gpgme_home)
-GPGME::Engine.home_dir = tmp_gpgme_home
+TMP_GPGME_HOME = File.expand_path("../../tmp/gpgme", __dir__)
+FileUtils.mkdir_p(TMP_GPGME_HOME)
+GPGME::Engine.home_dir = TMP_GPGME_HOME

--- a/spec/support/matchers/be_a_pgp_encrypted_message.rb
+++ b/spec/support/matchers/be_a_pgp_encrypted_message.rb
@@ -1,4 +1,22 @@
+# A following PGP matcher calls the GPG executable in a subshell, then
+# parses command output.  This is a poor pattern in general, because output
+# messages may subtly change over GPG evolution, and some maintenance work
+# may be required.
+#
+# However, GPG executables do not provide any machine-readable output which
+# could be used instead.  Furthermore, using RNP or GPGME from here is also
+# a poor idea, because this gem is going to be tested against various
+# combinations of software, in some of which that dependency may be unavailable.
+#
+# If parsing the output of GPG commands will become a burden, then the preferred
+# solution is to develop a minimalist validator which, if executed in
+# a subshell, returns some useful machine-readable output.  A validator tool
+# running in a separate process may leverage GPGME, as it won't be exposed
+# outside the validator.  A previous implementation of this matcher may provide
+# some useful ideas.  See commit 2e2bd0da090d7d31ecacc2d1ea6bd3e13479e675.
 RSpec::Matchers.define :be_a_pgp_encrypted_message do
+  include GpgMatcherHelper
+
   attr_reader :err, :expected_recipients
 
   match do |encrypted_string|
@@ -18,41 +36,50 @@ RSpec::Matchers.define :be_a_pgp_encrypted_message do
   end
 
   # Returns +nil+ if signature is valid, or an error message otherwise.
-  def validate_encrypted_message(encrypted)
-    cleartext_data = GPGME::Data.new
-    encrypted_data = GPGME::Data.new(encrypted)
+  def validate_encrypted_message(encrypted_string)
+    cmd_output = run_gpg_decrypt(encrypted_string)
+    cmd_result = analyse_decrypt_output(*cmd_output)
 
-    GPGME::Ctx.new do |ctx|
-      ctx.decrypt_verify(encrypted_data, cleartext_data)
-      cleartext = cleartext_data.to_s
-      cipher_info = ctx.decrypt_result
-      recipient_key_ids = cipher_info.recipients.map(&:keyid)
-      recipients = recipient_key_ids.map { |kid| GPGME::Key.get(kid).email }
-      match_cleartext_and_recipients(cleartext, recipients) ||
-        match_signature(ctx.verify_result.signatures.first)
-    end
-  rescue GPGME::Error::NoData # Signature parse error
-    msg_no_gpg_sig(encrypted)
-  end
-
-  def match_cleartext_and_recipients(cleartext, recipients)
-    case
-    when expected_cleartext && cleartext != expected_cleartext
-      msg_mismatch(cleartext)
-    when expected_recipients && expected_recipients.sort != recipients.sort
-      msg_wrong_recipients(recipients)
-    else # rubocop:disable Style/EmptyElse - redundant but explicit
-      nil
+    if cmd_result[:well_formed_pgp_data]
+      match_constraints(**cmd_result)
+    else
+      msg_no_pgg_data(encrypted_string)
     end
   end
 
-  def match_signature(sig)
-    case
-    when expected_signer && sig.key.email != expected_signer
-      msg_wrong_signer(sig.key.email)
-    else # rubocop:disable Style/EmptyElse - redundant but explicit
-      nil
-    end
+  def run_gpg_decrypt(encrypted_string)
+    enc_file = make_tempfile_containing(encrypted_string)
+    cmd = gpg_decrypt_command(enc_file)
+    run_command(cmd)
+  end
+
+  def analyse_decrypt_output(stdout_str, stderr_str, status)
+    {
+      well_formed_pgp_data: (status.exitstatus != 2),
+      recipients: detect_recipients(stderr_str),
+      signature: detect_signers(stderr_str).first,
+      cleartext: stdout_str,
+    }
+  end
+
+  def match_constraints(cleartext:, recipients:, signature:, **_ignored)
+    [
+      (expected_cleartext && match_cleartext(cleartext)),
+      (expected_recipients && match_recipients(recipients)),
+      (expected_signer && match_signature(signature)),
+    ].detect { |x| x }
+  end
+
+  def gpg_decrypt_command(enc_file)
+    homedir_path = Shellwords.escape(TMP_GPGME_HOME)
+    enc_path = Shellwords.escape(enc_file.path)
+
+    <<~SH
+      gpg \
+      --homedir #{homedir_path} \
+      --no-permission-warning \
+      --decrypt #{enc_path}
+    SH
   end
 
   def msg_mismatch(text)
@@ -60,9 +87,9 @@ RSpec::Matchers.define :be_a_pgp_encrypted_message do
       "text:\n#{expected_cleartext}\nbut was:\n#{text}"
   end
 
-  def msg_no_gpg_sig(sig_text)
-    "expected given text to be a valid Open PGP signature, " +
-      "but it contains no signature data, just:\n#{sig_text}"
+  def msg_no_pgg_data(file_text)
+    "expected given text to be a valid Open PGP encrypted message, " +
+      "but it contains no PGP data, just:\n#{file_text}"
   end
 
   def msg_wrong_recipients(recipients)

--- a/spec/support/matchers/be_a_valid_pgp_signature_of.rb
+++ b/spec/support/matchers/be_a_valid_pgp_signature_of.rb
@@ -1,8 +1,25 @@
+# A following PGP matcher calls the GPG executable in a subshell, then
+# parses command output.  This is a poor pattern in general, because output
+# messages may subtly change over GPG evolution.
+#
+# However, GPG executables do not provide any machine-readable output which
+# could be used instead.  Furthermore, using RNP or GPGME from here is also
+# a poor idea, because this gem is going to be tested against various
+# combinations of software, in some of which that dependency may be unavailable.
+#
+# If output parsing will ever become a source of problems, then the preferred
+# solution is to develop a minimalist validator which, if executed in
+# a subshell, returns useful machine-readable output.  A validator tool running
+# in a separate process may leverage GPGME, as it won't be exposed outside
+# the validator.  A previous implementation of this matcher may provide some
+# useful ideas.  See commit 2e2bd0da090d7d31ecacc2d1ea6bd3e13479e675.
 RSpec::Matchers.define :be_a_valid_pgp_signature_of do |text|
+  include GpgMatcherHelper
+
   attr_reader :err
 
   match do |signature_string|
-    @err = parse_and_validate_signature(signature_string, text)
+    @err = verify_signature(text, signature_string)
     @err.nil?
   end
 
@@ -13,28 +30,46 @@ RSpec::Matchers.define :be_a_valid_pgp_signature_of do |text|
   end
 
   # Returns +nil+ if first signature is valid, or an error message otherwise.
-  def parse_and_validate_signature(signature_string, text)
-    cleartext_data = GPGME::Data.new(text)
-    signature_data = GPGME::Data.new(signature_string)
+  def verify_signature(cleartext, signature_string)
+    cmd_output = run_gpg_verify(cleartext, signature_string)
+    cmd_result = analyse_verify_output(*cmd_output)
 
-    GPGME::Ctx.new(armor: true) do |ctx|
-      # That final +nil+ is obligatory
-      ctx.verify(signature_data, cleartext_data, nil)
-      match_signature(ctx.verify_result.signatures.first)
+    if cmd_result[:well_formed_pgp_data]
+      match_constraints(**cmd_result)
+    else
+      msg_no_pgg_data(signature_string)
     end
-  rescue GPGME::Error::NoData, GPGME::Error::General # Signature parse error
-    msg_no_gpg_sig(signature_string)
   end
 
-  def match_signature(sig)
-    case
-    when !sig.valid?
-      msg_mismatch(text)
-    when expected_signer && sig.key.email != expected_signer
-      msg_wrong_signer(sig.key.email)
-    else # rubocop:disable Style/EmptyElse - redundant but explicit
-      nil
-    end
+  def run_gpg_verify(cleartext, signature_string)
+    sig_file = make_tempfile_containing(signature_string)
+    data_file = make_tempfile_containing(cleartext)
+    cmd = gpg_verify_command(sig_file, data_file)
+    run_command(cmd)
+  end
+
+  def analyse_verify_output(_stdout_str, stderr_str, status)
+    {
+      well_formed_pgp_data: (status.exitstatus != 2),
+      signature: detect_signers(stderr_str).first,
+    }
+  end
+
+  def match_constraints(signature:, **_ignored)
+    match_signature(signature)
+  end
+
+  def gpg_verify_command(sig_file, data_file)
+    homedir_path = Shellwords.escape(TMP_GPGME_HOME)
+    sig_path = Shellwords.escape(sig_file.path)
+    data_path = Shellwords.escape(data_file.path)
+
+    <<~SH
+      gpg \
+      --homedir #{homedir_path} \
+      --no-permission-warning \
+      --verify #{sig_path} #{data_path}
+    SH
   end
 
   def msg_mismatch(text)
@@ -42,9 +77,9 @@ RSpec::Matchers.define :be_a_valid_pgp_signature_of do |text|
       "of following text:\n#{text}"
   end
 
-  def msg_no_gpg_sig(sig_text)
+  def msg_no_pgg_data(file_text)
     "expected given text to be a valid Open PGP signature, " +
-      "but it contains no signature data, just:\n#{sig_text}"
+      "but it contains no PGP data, just:\n#{file_text}"
   end
 
   def msg_wrong_signer(actual_signer)

--- a/spec/support/matchers/gpg_matcher_helper.rb
+++ b/spec/support/matchers/gpg_matcher_helper.rb
@@ -1,0 +1,55 @@
+require "open3"
+
+module GpgMatcherHelper
+  def detect_signers(stderr_str)
+    rx = /(?<ok>Good|BAD) signature from .*\<(?<email>[^>]+)\>/
+
+    stderr_str.to_enum(:scan, rx).map do
+      {
+        email: $~["email"],
+        ok: ($~["ok"] == "Good"),
+      }
+    end
+  end
+
+  def detect_recipients(stderr_str)
+    rx = /encrypted with .*\n.*\<(?<email>[^>]+)\>/
+
+    stderr_str.to_enum(:scan, rx).map do
+      $~["email"]
+    end
+  end
+
+  def match_cleartext(cleartext)
+    if cleartext != expected_cleartext
+      msg_mismatch(cleartext)
+    end
+  end
+
+  def match_recipients(recipients)
+    if expected_recipients.sort != recipients.sort
+      msg_wrong_recipients(recipients)
+    end
+  end
+
+  # Checks if signature is valid.  If `expected_signer` is not `nil`, then it
+  # additionally checks if the signature was issued by expected signer.
+  def match_signature(signature)
+    if !signature[:ok]
+      msg_mismatch(text)
+    elsif expected_signer && signature[:email] != expected_signer
+      msg_wrong_signer(signature[:email])
+    end
+  end
+
+  def make_tempfile_containing(file_content)
+    tempfile = Tempfile.new
+    tempfile.write(file_content)
+    tempfile.flush
+  end
+
+  def run_command(cmd)
+    env = { "LC_ALL" => "C" } # Gettext English locale
+    Open3.capture3(env, cmd)
+  end
+end


### PR DESCRIPTION
Rewrite PGP matchers from scratch so that they execute GPG in a subshell instead of using GPGME.  The reason is to reduce matchers' dependencies, and make them working when GPGME library is not available, which may happen when testing against different combinations of optional dependencies.