### PR TITLE
Add support for arbitrary cipher adapters

### DIFF
--- a/lib/enmail.rb
+++ b/lib/enmail.rb
@@ -12,8 +12,8 @@ require "enmail/adapters/gpgme"
 module EnMail
   module_function
 
-  def protect(mode, message, **options)
-    adapter = Adapters::GPGME.new(options)
-    adapter.public_send mode, message
+  def protect(mode, message, adapter:, **options)
+    adapter_obj = adapter.new(options)
+    adapter_obj.public_send mode, message
   end
 end

--- a/spec/acceptance/gpgme/encrypt_spec.rb
+++ b/spec/acceptance/gpgme/encrypt_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "Encrypting with GPGME" do
   specify "a non-multipart text-only message" do
     mail = simple_mail
 
-    EnMail.protect :encrypt, mail
+    EnMail.protect :encrypt, mail, adapter: adapter_class
     mail.deliver
     common_message_expectations(mail)
     pgp_encrypted_part_expectations(mail)
@@ -18,7 +18,7 @@ RSpec.describe "Encrypting with GPGME" do
   specify "a non-multipart HTML message" do
     mail = simple_html_mail
 
-    EnMail.protect :encrypt, mail
+    EnMail.protect :encrypt, mail, adapter: adapter_class
     mail.deliver
     common_message_expectations(mail)
     pgp_encrypted_part_expectations(mail)
@@ -28,7 +28,7 @@ RSpec.describe "Encrypting with GPGME" do
   specify "a multipart text+HTML message" do
     mail = text_html_mail
 
-    EnMail.protect :encrypt, mail
+    EnMail.protect :encrypt, mail, adapter: adapter_class
     mail.deliver
     common_message_expectations(mail)
     pgp_encrypted_part_expectations(mail)
@@ -38,7 +38,7 @@ RSpec.describe "Encrypting with GPGME" do
   specify "a multipart message with binary attachments" do
     mail = text_jpeg_mail
 
-    EnMail.protect :encrypt, mail
+    EnMail.protect :encrypt, mail, adapter: adapter_class
     mail.deliver
     common_message_expectations(mail)
     pgp_encrypted_part_expectations(mail)

--- a/spec/acceptance/gpgme/sign_and_encrypt_combined_spec.rb
+++ b/spec/acceptance/gpgme/sign_and_encrypt_combined_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "Signing and encrypting in combined fashion with GPGME" do
   specify "a non-multipart text-only message" do
     mail = simple_mail
 
-    EnMail.protect :sign_and_encrypt_combined, mail
+    EnMail.protect :sign_and_encrypt_combined, mail, adapter: adapter_class
     mail.deliver
     common_message_expectations(mail)
     pgp_signed_and_encrypted_part_expectations(mail)
@@ -19,7 +19,7 @@ RSpec.describe "Signing and encrypting in combined fashion with GPGME" do
   specify "a non-multipart HTML message" do
     mail = simple_html_mail
 
-    EnMail.protect :sign_and_encrypt_combined, mail
+    EnMail.protect :sign_and_encrypt_combined, mail, adapter: adapter_class
     mail.deliver
     common_message_expectations(mail)
     pgp_signed_and_encrypted_part_expectations(mail)
@@ -30,7 +30,7 @@ RSpec.describe "Signing and encrypting in combined fashion with GPGME" do
   specify "a multipart text+HTML message" do
     mail = text_html_mail
 
-    EnMail.protect :sign_and_encrypt_combined, mail
+    EnMail.protect :sign_and_encrypt_combined, mail, adapter: adapter_class
     mail.deliver
     common_message_expectations(mail)
     pgp_signed_and_encrypted_part_expectations(mail)
@@ -41,7 +41,7 @@ RSpec.describe "Signing and encrypting in combined fashion with GPGME" do
   specify "a multipart message with binary attachments" do
     mail = text_jpeg_mail
 
-    EnMail.protect :sign_and_encrypt_combined, mail
+    EnMail.protect :sign_and_encrypt_combined, mail, adapter: adapter_class
     mail.deliver
     common_message_expectations(mail)
     pgp_signed_and_encrypted_part_expectations(mail)

--- a/spec/acceptance/gpgme/sign_and_encrypt_encapsulated_spec.rb
+++ b/spec/acceptance/gpgme/sign_and_encrypt_encapsulated_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "Signing and encrypting in encapsulated fashion with GPGME" do
   specify "a non-multipart text-only message" do
     mail = simple_mail
 
-    EnMail.protect :sign_and_encrypt_encapsulated, mail
+    EnMail.protect :sign_and_encrypt_encapsulated, mail, adapter: adapter_class
     mail.deliver
     common_message_expectations(mail)
     pgp_encrypted_part_expectations(mail)
@@ -20,7 +20,7 @@ RSpec.describe "Signing and encrypting in encapsulated fashion with GPGME" do
   specify "a non-multipart HTML message" do
     mail = simple_html_mail
 
-    EnMail.protect :sign_and_encrypt_encapsulated, mail
+    EnMail.protect :sign_and_encrypt_encapsulated, mail, adapter: adapter_class
     mail.deliver
     common_message_expectations(mail)
     pgp_encrypted_part_expectations(mail)
@@ -32,7 +32,7 @@ RSpec.describe "Signing and encrypting in encapsulated fashion with GPGME" do
   specify "a multipart text+HTML message" do
     mail = text_html_mail
 
-    EnMail.protect :sign_and_encrypt_encapsulated, mail
+    EnMail.protect :sign_and_encrypt_encapsulated, mail, adapter: adapter_class
     mail.deliver
     common_message_expectations(mail)
     pgp_encrypted_part_expectations(mail)
@@ -44,7 +44,7 @@ RSpec.describe "Signing and encrypting in encapsulated fashion with GPGME" do
   specify "a multipart message with binary attachments" do
     mail = text_jpeg_mail
 
-    EnMail.protect :sign_and_encrypt_encapsulated, mail
+    EnMail.protect :sign_and_encrypt_encapsulated, mail, adapter: adapter_class
     mail.deliver
     common_message_expectations(mail)
     pgp_encrypted_part_expectations(mail)

--- a/spec/acceptance/gpgme/sign_spec.rb
+++ b/spec/acceptance/gpgme/sign_spec.rb
@@ -3,11 +3,12 @@ require "spec_helper"
 RSpec.describe "Signing with GPGME" do
   include_context "example emails"
   include_context "expectations for example emails"
+  include_context "gpgme spec helpers"
 
   specify "a non-multipart text-only message" do
     mail = simple_mail
 
-    EnMail.protect :sign, mail
+    EnMail.protect :sign, mail, adapter: adapter_class
     mail.deliver
     common_message_expectations(mail)
     pgp_signed_part_expectations(mail)
@@ -17,7 +18,7 @@ RSpec.describe "Signing with GPGME" do
   specify "a non-multipart HTML message" do
     mail = simple_html_mail
 
-    EnMail.protect :sign, mail
+    EnMail.protect :sign, mail, adapter: adapter_class
     mail.deliver
     common_message_expectations(mail)
     pgp_signed_part_expectations(mail)
@@ -27,7 +28,7 @@ RSpec.describe "Signing with GPGME" do
   specify "a multipart text+HTML message" do
     mail = text_html_mail
 
-    EnMail.protect :sign, mail
+    EnMail.protect :sign, mail, adapter: adapter_class
     mail.deliver
     common_message_expectations(mail)
     pgp_signed_part_expectations(mail)
@@ -37,7 +38,7 @@ RSpec.describe "Signing with GPGME" do
   specify "a multipart message with binary attachments" do
     mail = text_jpeg_mail
 
-    EnMail.protect :sign, mail
+    EnMail.protect :sign, mail, adapter: adapter_class
     mail.deliver
     common_message_expectations(mail)
     pgp_signed_part_expectations(mail)
@@ -48,7 +49,7 @@ RSpec.describe "Signing with GPGME" do
     mail = simple_mail
     signer = "whatever@example.test"
 
-    EnMail.protect :sign, mail, signer: signer
+    EnMail.protect :sign, mail, adapter: adapter_class, signer: signer
     mail.deliver
     common_message_expectations(mail)
     pgp_signed_part_expectations(mail, expected_signer: signer)

--- a/spec/support/gpgme_spec_helpers.rb
+++ b/spec/support/gpgme_spec_helpers.rb
@@ -4,4 +4,8 @@ shared_context "gpgme spec helpers" do
     decrypted_raw_message = GPGME::Crypto.new.decrypt(encrypted_message)
     Mail::Part.new(decrypted_raw_message)
   end
+
+  def adapter_class
+    ::EnMail::Adapters::GPGME
+  end
 end

--- a/spec/unit/enmail_spec.rb
+++ b/spec/unit/enmail_spec.rb
@@ -2,19 +2,19 @@ RSpec.describe EnMail do
   describe "::protect" do
     subject { EnMail.method(:protect) }
 
-    let(:adapter_class) { EnMail::Adapters::GPGME }
-    let(:adapter_dbl) { instance_double(adapter_class, sign: nil) }
+    let(:adapter_class) { Class.new }
+    let(:adapter_dbl) { double(sign: nil) }
     let(:message) { Mail.new }
 
     before { allow(adapter_class).to receive(:new).and_return(adapter_dbl) }
 
     it "instantiates an adapter with proper options" do
-      subject.call :sign, message, proper: :options
+      subject.call :sign, message, adapter: adapter_class, proper: :options
       expect(adapter_class).to have_received(:new).with(proper: :options)
     end
 
     it "calls indicated method on adapter, passing a message as an argument" do
-      subject.call :sign, message
+      subject.call :sign, message, adapter: adapter_class
       expect(adapter_dbl).to have_received(:sign).with(message)
     end
   end

--- a/spec/unit/enmail_spec.rb
+++ b/spec/unit/enmail_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe EnMail do
       expect(adapter_class).to have_received(:new).with(proper: :options)
     end
 
-    it "calls indicated method, passing a message as an argument" do
+    it "calls indicated method on adapter, passing a message as an argument" do
       subject.call :sign, message
       expect(adapter_dbl).to have_received(:sign).with(message)
     end


### PR DESCRIPTION
From now, EnMail can use arbitrary adapter. There are no defaults, old good GPGME must be specified explicitly.