### PR TITLE
Use RSA keypairs in tests, and specify key usages

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -11,30 +11,36 @@ task :generate_gpg_keys => :init_gpgme do # rubocop:disable Style/HashSyntax
   ::GPGME::Ctx.new.genkey(<<~SCRIPT)
     <GnupgKeyParms format="internal">
     %no-protection
-    Key-Type: DSA
+    Key-Type: RSA
+    Key-Usage: sign, cert
     Key-Length: 2048
-    Subkey-Type: ELG-E
+    Subkey-Type: RSA
     Subkey-Length: 2048
+    Subkey-Usage: encrypt
     Name-Real: Some Arbitrary Key
     Name-Email: whatever@example.test
     Name-Comment: Without passphrase
     Expire-Date: 0
     %commit
 
-    Key-Type: DSA
+    Key-Type: RSA
+    Key-Usage: sign, cert
     Key-Length: 2048
-    Subkey-Type: ELG-E
+    Subkey-Type: RSA
     Subkey-Length: 2048
+    Subkey-Usage: encrypt
     Name-Real: Cato Elder
     Name-Email: cato.elder@example.test
     Name-Comment: Without passphrase
     Expire-Date: 0
     %commit
 
-    Key-Type: DSA
+    Key-Type: RSA
+    Key-Usage: sign, cert
     Key-Length: 2048
-    Subkey-Type: ELG-E
+    Subkey-Type: RSA
     Subkey-Length: 2048
+    Subkey-Usage: encrypt
     Name-Real: Roman Senate
     Name-Email: senate@example.test
     Name-Comment: Without passphrase


### PR DESCRIPTION
Previous settings were copied from some example found in GnuPG documentation, but were useless for a planned RNP adaper, as it seems that RNP refuses to sign documents wtih DSA keys.

RSA is generally more common, and has much better support in RNP. Actually, the updated GnupgKeyParms resemble default GnuPG settings, however writing them explicitly should prevent from surprises related to software updates.

Apart from algorithm changes, key usages have been specified for clarity. They resemble default GnuPG settings as well.