### PR TITLE
Implement OpenPGP adapter which uses RNP

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,18 @@ env:
       --disable-pinentry-qt --disable-pinentry-qt4 --disable-pinentry-qt5
       --disable-pinentry-tqt --disable-pinentry-fltk"
 
+    - RNP_VERSION="master"
+    - LOCAL_BUILDS="$TRAVIS_BUILD_DIR/build_rnp"
+    - BOTAN_INSTALL="$TRAVIS_BUILD_DIR/opt"
+    - CMOCKA_INSTALL="$TRAVIS_BUILD_DIR/opt"
+    - JSONC_INSTALL="$TRAVIS_BUILD_DIR/opt"
+    - RNP_INSTALL="$TRAVIS_BUILD_DIR/opt"
+
+    - LD_LIBRARY_PATH="$TRAVIS_BUILD_DIR/opt/lib"
+
 before_install:
   - ./install_gpg_all.sh "$GPG_VERSION" --build-dir "$GPG_BUILD_DIR" --configure-opts "$GPG_CONFIGURE_OPTS" --folding-style travis
+  - ./install_rnp.sh
   - gem install bundler -v 1.16.1
 
 before_script:

--- a/enmail.gemspec
+++ b/enmail.gemspec
@@ -31,4 +31,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 3.0"
 
   spec.add_development_dependency "gpgme"
+  spec.add_development_dependency "rnp", ">= 1.0.1", "< 2"
 end

--- a/install_rnp.sh
+++ b/install_rnp.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+# Copied from:
+# https://github.com/riboseinc/ruby-rnp/blob/52d6113458cb095cf7811/ci/install.sh
+set -eux
+
+: "${CORES:=2}"
+: "${MAKE:=make}"
+
+# botan
+botan_build=${LOCAL_BUILDS}/botan
+if [ ! -e "${BOTAN_INSTALL}/lib/libbotan-2.so" ] && \
+	 [ ! -e "${BOTAN_INSTALL}/lib/libbotan-2.dylib" ]; then
+
+	if [ -d "${botan_build}" ]; then
+		rm -rf "${botan_build}"
+	fi
+
+	git clone --depth 1 https://github.com/randombit/botan "${botan_build}"
+	pushd "${botan_build}"
+	./configure.py --prefix="${BOTAN_INSTALL}" --with-debug-info --cxxflags="-fno-omit-frame-pointer"
+	${MAKE} -j${CORES} install
+	popd
+fi
+
+# json-c
+jsonc_build=${LOCAL_BUILDS}/json-c
+if [ ! -e "${JSONC_INSTALL}/lib/libjson-c.so" ] && \
+	 [ ! -e "${JSONC_INSTALL}/lib/libjson-c.dylib" ]; then
+
+	 if [ -d "${jsonc_build}" ]; then
+		 rm -rf "${jsonc_build}"
+	 fi
+
+	mkdir -p "${jsonc_build}"
+	pushd ${jsonc_build}
+	wget https://s3.amazonaws.com/json-c_releases/releases/json-c-0.12.1.tar.gz -O json-c.tar.gz
+	tar xzf json-c.tar.gz --strip 1
+
+	autoreconf -ivf
+	env CFLAGS="-fno-omit-frame-pointer -g" ./configure --prefix="${JSONC_INSTALL}"
+	${MAKE} -j${CORES} install
+	popd
+fi
+
+# rnp
+rnp_build=${LOCAL_BUILDS}/rnp
+if [ ! -e "${RNP_INSTALL}/lib/librnp.so" ] && \
+	 [ ! -e "${RNP_INSTALL}/lib/librnp.dylib" ]; then
+
+	git clone https://github.com/riboseinc/rnp ${rnp_build}
+	pushd "${rnp_build}"
+	git checkout "$RNP_VERSION"
+	cmake \
+		-DCMAKE_BUILD_TYPE=RelWithDebInfo \
+		-DBUILD_SHARED_LIBS=yes \
+		-DBUILD_TESTING=no \
+		-DCMAKE_PREFIX_PATH="${BOTAN_INSTALL};${JSONC_INSTALL}" \
+		-DCMAKE_INSTALL_PREFIX="${RNP_INSTALL}" \
+		.
+	${MAKE} -j${CORES} install
+	popd
+fi

--- a/lib/enmail.rb
+++ b/lib/enmail.rb
@@ -8,6 +8,7 @@ require "enmail/helpers/rfc3156"
 
 require "enmail/adapters/base"
 require "enmail/adapters/gpgme"
+require "enmail/adapters/rnp"
 
 module EnMail
   module_function

--- a/lib/enmail/adapters/rnp.rb
+++ b/lib/enmail/adapters/rnp.rb
@@ -1,0 +1,93 @@
+require "rnp"
+
+module EnMail
+  module Adapters
+    # Secures e-mails according to {RFC 3156 "MIME Security with OpenPGP"}[
+    # https://tools.ietf.org/html/rfc3156].
+    #
+    # This adapter uses {RNP}[https://github.com/riboseinc/rnp] library via
+    # {ruby-rnp gem}[https://github.com/riboseinc/ruby-rnp].
+    #
+    # NOTE: `Rnp` instances are not thread-safe, and neither this adapter is.
+    # Any adapter instance should be accessed by at most one thread at a time.
+    class RNP < Base
+      include Helpers::MessageManipulation
+      include Helpers::RFC1847
+      include Helpers::RFC3156
+
+      attr_reader :rnp
+
+      def initialize(*args)
+        super
+        @rnp = build_rnp_and_load_keys
+      end
+
+      private
+
+      def compute_signature(text, signer)
+        signer_key = find_key_for(signer, need_secret: true)
+
+        rnp.detached_sign(
+          signers: [signer_key],
+          input: build_input(text),
+          armored: true,
+        )
+      end
+
+      def encrypt_string(text, recipients)
+        recipient_keys =
+          recipients.map { |r| find_key_for(r, need_public: true) }
+
+        rnp.encrypt(
+          recipients: recipient_keys,
+          input: build_input(text),
+          armored: true,
+        )
+      end
+
+      def sign_and_encrypt_string(text, signer, recipients)
+        signer_key = find_key_for(signer, need_secret: true)
+        recipient_keys =
+          recipients.map { |r| find_key_for(r, need_public: true) }
+
+        rnp.encrypt_and_sign(
+          recipients: recipient_keys,
+          signers: signer_key,
+          input: build_input(text),
+          armored: true,
+        )
+      end
+
+      def find_key_for(email, need_public: false, need_secret: false)
+        rnp.each_keyid do |keyid|
+          key = rnp.find_key(keyid: keyid)
+          next if need_public && !key.public_key_present?
+          next if need_secret && !key.secret_key_present?
+
+          key.each_userid do |userid|
+            return key if userid.include?(email)
+          end
+        end
+        nil
+      end
+
+      def build_input(text)
+        ::Rnp::Input.from_string(text)
+      end
+
+      def build_rnp_and_load_keys(homedir = Rnp.default_homedir)
+        homedir_info = ::Rnp.homedir_info(homedir)
+        public_info, secret_info = homedir_info.values_at(:public, :secret)
+
+        rnp = Rnp.new(public_info[:format], secret_info[:format])
+
+        [public_info, secret_info].each do |keyring_info|
+          input = ::Rnp::Input.from_path(keyring_info[:path])
+          rnp.load_keys(format: keyring_info[:format], input: input)
+        end
+
+        rnp
+      end
+    end
+  end
+end

--- a/spec/acceptance/rnp/encrypt_spec.rb
+++ b/spec/acceptance/rnp/encrypt_spec.rb
@@ -1,0 +1,47 @@
+require "spec_helper"
+
+RSpec.describe "Encrypting with RNP" do
+  include_context "example emails"
+  include_context "expectations for example emails"
+  include_context "rnp spec helpers"
+
+  specify "a non-multipart text-only message" do
+    mail = simple_mail
+
+    EnMail.protect :encrypt, mail, adapter: adapter_class
+    mail.deliver
+    common_message_expectations(mail)
+    pgp_encrypted_part_expectations(mail)
+    decrypted_part_expectations_for_simple_mail(decrypt_mail(mail))
+  end
+
+  specify "a non-multipart HTML message" do
+    mail = simple_html_mail
+
+    EnMail.protect :encrypt, mail, adapter: adapter_class
+    mail.deliver
+    common_message_expectations(mail)
+    pgp_encrypted_part_expectations(mail)
+    decrypted_part_expectations_for_simple_html_mail(decrypt_mail(mail))
+  end
+
+  specify "a multipart text+HTML message" do
+    mail = text_html_mail
+
+    EnMail.protect :encrypt, mail, adapter: adapter_class
+    mail.deliver
+    common_message_expectations(mail)
+    pgp_encrypted_part_expectations(mail)
+    decrypted_part_expectations_for_text_html_mail(decrypt_mail(mail))
+  end
+
+  specify "a multipart message with binary attachments" do
+    mail = text_jpeg_mail
+
+    EnMail.protect :encrypt, mail, adapter: adapter_class
+    mail.deliver
+    common_message_expectations(mail)
+    pgp_encrypted_part_expectations(mail)
+    decrypted_part_expectations_for_text_jpeg_mail(decrypt_mail(mail))
+  end
+end

--- a/spec/acceptance/rnp/sign_and_encrypt_combined_spec.rb
+++ b/spec/acceptance/rnp/sign_and_encrypt_combined_spec.rb
@@ -1,0 +1,51 @@
+require "spec_helper"
+
+RSpec.describe "Signing and encrypting in combined fashion with RNP" do
+  include_context "example emails"
+  include_context "expectations for example emails"
+  include_context "rnp spec helpers"
+
+  specify "a non-multipart text-only message" do
+    mail = simple_mail
+
+    EnMail.protect :sign_and_encrypt_combined, mail, adapter: adapter_class
+    mail.deliver
+    common_message_expectations(mail)
+    pgp_signed_and_encrypted_part_expectations(mail)
+    decrypted_mail = decrypt_mail(mail)
+    decrypted_part_expectations_for_simple_mail(decrypted_mail)
+  end
+
+  specify "a non-multipart HTML message" do
+    mail = simple_html_mail
+
+    EnMail.protect :sign_and_encrypt_combined, mail, adapter: adapter_class
+    mail.deliver
+    common_message_expectations(mail)
+    pgp_signed_and_encrypted_part_expectations(mail)
+    decrypted_mail = decrypt_mail(mail)
+    decrypted_part_expectations_for_simple_html_mail(decrypted_mail)
+  end
+
+  specify "a multipart text+HTML message" do
+    mail = text_html_mail
+
+    EnMail.protect :sign_and_encrypt_combined, mail, adapter: adapter_class
+    mail.deliver
+    common_message_expectations(mail)
+    pgp_signed_and_encrypted_part_expectations(mail)
+    decrypted_mail = decrypt_mail(mail)
+    decrypted_part_expectations_for_text_html_mail(decrypted_mail)
+  end
+
+  specify "a multipart message with binary attachments" do
+    mail = text_jpeg_mail
+
+    EnMail.protect :sign_and_encrypt_combined, mail, adapter: adapter_class
+    mail.deliver
+    common_message_expectations(mail)
+    pgp_signed_and_encrypted_part_expectations(mail)
+    decrypted_mail = decrypt_mail(mail)
+    decrypted_part_expectations_for_text_jpeg_mail(decrypted_mail)
+  end
+end

--- a/spec/acceptance/rnp/sign_and_encrypt_encapsulated_spec.rb
+++ b/spec/acceptance/rnp/sign_and_encrypt_encapsulated_spec.rb
@@ -1,0 +1,55 @@
+require "spec_helper"
+
+RSpec.describe "Signing and encrypting in encapsulated fashion with RNP" do
+  include_context "example emails"
+  include_context "expectations for example emails"
+  include_context "rnp spec helpers"
+
+  specify "a non-multipart text-only message" do
+    mail = simple_mail
+
+    EnMail.protect :sign_and_encrypt_encapsulated, mail, adapter: adapter_class
+    mail.deliver
+    common_message_expectations(mail)
+    pgp_encrypted_part_expectations(mail)
+    decrypted_mail = decrypt_mail(mail)
+    pgp_signed_part_expectations(decrypted_mail)
+    decrypted_part_expectations_for_simple_mail(decrypted_mail.parts[0])
+  end
+
+  specify "a non-multipart HTML message" do
+    mail = simple_html_mail
+
+    EnMail.protect :sign_and_encrypt_encapsulated, mail, adapter: adapter_class
+    mail.deliver
+    common_message_expectations(mail)
+    pgp_encrypted_part_expectations(mail)
+    decrypted_mail = decrypt_mail(mail)
+    pgp_signed_part_expectations(decrypted_mail)
+    decrypted_part_expectations_for_simple_html_mail(decrypted_mail.parts[0])
+  end
+
+  specify "a multipart text+HTML message" do
+    mail = text_html_mail
+
+    EnMail.protect :sign_and_encrypt_encapsulated, mail, adapter: adapter_class
+    mail.deliver
+    common_message_expectations(mail)
+    pgp_encrypted_part_expectations(mail)
+    decrypted_mail = decrypt_mail(mail)
+    pgp_signed_part_expectations(decrypted_mail)
+    decrypted_part_expectations_for_text_html_mail(decrypted_mail.parts[0])
+  end
+
+  specify "a multipart message with binary attachments" do
+    mail = text_jpeg_mail
+
+    EnMail.protect :sign_and_encrypt_encapsulated, mail, adapter: adapter_class
+    mail.deliver
+    common_message_expectations(mail)
+    pgp_encrypted_part_expectations(mail)
+    decrypted_mail = decrypt_mail(mail)
+    pgp_signed_part_expectations(decrypted_mail)
+    decrypted_part_expectations_for_text_jpeg_mail(decrypted_mail.parts[0])
+  end
+end

--- a/spec/acceptance/rnp/sign_spec.rb
+++ b/spec/acceptance/rnp/sign_spec.rb
@@ -1,0 +1,58 @@
+require "spec_helper"
+
+RSpec.describe "Signing with RNP" do
+  include_context "example emails"
+  include_context "expectations for example emails"
+  include_context "rnp spec helpers"
+
+  specify "a non-multipart text-only message" do
+    mail = simple_mail
+
+    EnMail.protect :sign, mail, adapter: adapter_class
+    mail.deliver
+    common_message_expectations(mail)
+    pgp_signed_part_expectations(mail)
+    decrypted_part_expectations_for_simple_mail(mail.parts[0])
+  end
+
+  specify "a non-multipart HTML message" do
+    mail = simple_html_mail
+
+    EnMail.protect :sign, mail, adapter: adapter_class
+    mail.deliver
+    common_message_expectations(mail)
+    pgp_signed_part_expectations(mail)
+    decrypted_part_expectations_for_simple_html_mail(mail.parts[0])
+  end
+
+  specify "a multipart text+HTML message" do
+    mail = text_html_mail
+
+    EnMail.protect :sign, mail, adapter: adapter_class
+    mail.deliver
+    common_message_expectations(mail)
+    pgp_signed_part_expectations(mail)
+    decrypted_part_expectations_for_text_html_mail(mail.parts[0])
+  end
+
+  specify "a multipart message with binary attachments" do
+    mail = text_jpeg_mail
+
+    EnMail.protect :sign, mail, adapter: adapter_class
+    mail.deliver
+    common_message_expectations(mail)
+    pgp_signed_part_expectations(mail)
+    decrypted_part_expectations_for_text_jpeg_mail(mail.parts[0])
+  end
+
+  specify "forcing different signer key" do
+    mail = simple_mail
+    signer = "whatever@example.test"
+
+    EnMail.protect :sign, mail, adapter: adapter_class, signer: signer
+    mail.deliver
+    common_message_expectations(mail)
+    pgp_signed_part_expectations(mail, expected_signer: signer)
+    decrypted_part_expectations_for_simple_mail(mail.parts[0])
+  end
+end

--- a/spec/support/rnp_setup.rb
+++ b/spec/support/rnp_setup.rb
@@ -1,0 +1,10 @@
+# Keep tmp directory as short as possible.  UNIX has some annoying limit
+# on file name length of the socket, and GPGME makes use of UNIX sockets.
+# Directory name produced by +Dir.mktmpdir+ is often quite long, and that
+# may cause weird error with misleading message.
+TMP_RNP_HOME = File.expand_path("../../tmp/gpgme", __dir__)
+FileUtils.mkdir_p(TMP_RNP_HOME)
+
+def Rnp.default_homedir
+  TMP_RNP_HOME
+end

--- a/spec/support/rnp_spec_helpers.rb
+++ b/spec/support/rnp_spec_helpers.rb
@@ -1,0 +1,17 @@
+shared_context "rnp spec helpers" do
+  # This method is an exact copy of one from "gpgme spec helpers" context.
+  # It's okay for now because both RNP and GPGME use the same homedir.
+  # However it will become a problem when we start testing against different
+  # software combinations, in which GPGME availability will not be guaranteed.
+  #
+  # TODO Make it using RNP
+  def decrypt_mail(message)
+    encrypted_message = message.parts[1].body.decoded
+    decrypted_raw_message = GPGME::Crypto.new.decrypt(encrypted_message)
+    Mail::Part.new(decrypted_raw_message)
+  end
+
+  def adapter_class
+    ::EnMail::Adapters::RNP
+  end
+end

--- a/spec/unit/adapters/rnp_spec.rb
+++ b/spec/unit/adapters/rnp_spec.rb
@@ -1,0 +1,57 @@
+require "spec_helper"
+
+RSpec.describe EnMail::Adapters::RNP do
+  let(:adapter) { described_class.new(options) }
+  let(:options) { {} }
+
+  include_context "example emails"
+
+  describe "#compute_signature" do
+    subject { adapter.method(:compute_signature) }
+    let(:text) { "Some Text." }
+    let(:signer) { "cato.elder@example.test" }
+
+    it "computes a detached signature for given text signed by given user" do
+      retval = subject.(text, signer)
+      expect(retval).to be_a_valid_pgp_signature_of(text).signed_by(signer)
+    end
+  end
+
+  describe "#encrypt_string" do
+    subject { adapter.method(:encrypt_string) }
+    let(:text) { "Some Text." }
+    let(:recipients) { %w[whatever@example.test senate@example.test] }
+
+    it "encrypts given text" do
+      retval = subject.(text, recipients)
+      expect(retval).to be_a_pgp_encrypted_message.containing(text)
+    end
+
+    it "makes the encrypted text readable for given recipients" do
+      retval = subject.(text, recipients)
+      expect(retval).to be_a_pgp_encrypted_message.encrypted_for(*recipients)
+    end
+  end
+
+  describe "#sign_and_encrypt_string" do
+    subject { adapter.method(:sign_and_encrypt_string) }
+    let(:text) { "Some Text." }
+    let(:recipients) { %w[whatever@example.test senate@example.test] }
+    let(:signer) { "cato.elder@example.test" }
+
+    it "encrypts given text" do
+      retval = subject.(text, signer, recipients)
+      expect(retval).to be_a_pgp_encrypted_message.containing(text)
+    end
+
+    it "makes the encrypted text readable for given recipients" do
+      retval = subject.(text, signer, recipients)
+      expect(retval).to be_a_pgp_encrypted_message.encrypted_for(*recipients)
+    end
+
+    it "adds a signature by given user to the encrypted text" do
+      retval = subject.(text, signer, recipients)
+      expect(retval).to be_a_pgp_encrypted_message.signed_by(signer)
+    end
+  end
+end


### PR DESCRIPTION
Implement brand new adapter which signs or encrypts messages in OpenPGP fashion with [RNP](https://www.rnpgp.com/). Fixes #53.