### PR TITLE
Use content transfer encoding which always preserves exact message content, no matter of SMTP discrepancies

### DIFF
--- a/lib/enmail.rb
+++ b/lib/enmail.rb
@@ -10,6 +10,8 @@ require "enmail/adapters/base"
 require "enmail/adapters/gpgme"
 require "enmail/adapters/rnp"
 
+require "enmail/extensions/message_transport_encoding_restrictions"
+
 module EnMail
   module_function
 
@@ -18,3 +20,5 @@ module EnMail
     adapter_obj.public_send mode, message
   end
 end
+
+Mail::Message.prepend EnMail::Extensions::MessageTransportEncodingRestrictions

--- a/lib/enmail/extensions/message_transport_encoding_restrictions.rb
+++ b/lib/enmail/extensions/message_transport_encoding_restrictions.rb
@@ -1,0 +1,17 @@
+module EnMail
+  module Extensions
+    module MessageTransportEncodingRestrictions
+      def identify_and_set_transfer_encoding
+        if @enmail_rfc18467_encoding_restrictions && !multipart?
+          str = body.raw_source
+          self.content_transfer_encoding = [
+            ::Mail::Encodings::Base64,
+            ::Mail::Encodings::QuotedPrintable,
+          ].min { |a, b| a.cost(str) <=> b.cost(str) }
+        else
+          super
+        end
+      end
+    end
+  end
+end

--- a/lib/enmail/helpers/rfc1847.rb
+++ b/lib/enmail/helpers/rfc1847.rb
@@ -44,6 +44,15 @@ module EnMail
 
       protected
 
+      def restrict_encoding(part)
+        if part.multipart?
+          part.parts.each { |p| restrict_encoding(p) }
+        else
+          ivar = "@enmail_rfc18467_encoding_restrictions"
+          part.instance_variable_set(ivar, true)
+        end
+      end
+
       # Builds a mail part containing the encrypted message, that is
       # the 2nd subpart of +multipart/encrypted+ as defined in RFC 1847.
       def build_encrypted_part(encrypted)

--- a/lib/enmail/helpers/rfc1847.rb
+++ b/lib/enmail/helpers/rfc1847.rb
@@ -31,6 +31,7 @@ module EnMail
       #   Message which is expected to be signed.
       def sign(message)
         source_part = body_to_part(message)
+        restrict_encoding(source_part)
         signer = find_signer_for(message)
         signature = compute_signature(source_part.encoded, signer).to_s
         signature_part = build_signature_part(signature)

--- a/lib/enmail/helpers/rfc3156.rb
+++ b/lib/enmail/helpers/rfc3156.rb
@@ -15,6 +15,7 @@ module EnMail
       # rubocop:disable Metrics/MethodLength
       def sign_and_encrypt_combined(message)
         source_part = body_to_part(message)
+        restrict_encoding(source_part)
         signer = find_signer_for(message)
         recipients = find_recipients_for(message)
         encrypted =

--- a/spec/acceptance/gpgme/sign_and_encrypt_combined_spec.rb
+++ b/spec/acceptance/gpgme/sign_and_encrypt_combined_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe "Signing and encrypting in combined fashion with GPGME" do
     pgp_signed_and_encrypted_part_expectations(mail)
     decrypted_mail = decrypt_mail(mail)
     decrypted_part_expectations_for_simple_mail(decrypted_mail)
+    resilent_transport_encoding_expectations(decrypted_mail)
   end
 
   specify "a non-multipart HTML message" do
@@ -25,6 +26,7 @@ RSpec.describe "Signing and encrypting in combined fashion with GPGME" do
     pgp_signed_and_encrypted_part_expectations(mail)
     decrypted_mail = decrypt_mail(mail)
     decrypted_part_expectations_for_simple_html_mail(decrypted_mail)
+    resilent_transport_encoding_expectations(decrypted_mail)
   end
 
   specify "a multipart text+HTML message" do
@@ -36,6 +38,8 @@ RSpec.describe "Signing and encrypting in combined fashion with GPGME" do
     pgp_signed_and_encrypted_part_expectations(mail)
     decrypted_mail = decrypt_mail(mail)
     decrypted_part_expectations_for_text_html_mail(decrypted_mail)
+    resilent_transport_encoding_expectations(decrypted_mail.parts[0])
+    resilent_transport_encoding_expectations(decrypted_mail.parts[1])
   end
 
   specify "a multipart message with binary attachments" do
@@ -47,5 +51,7 @@ RSpec.describe "Signing and encrypting in combined fashion with GPGME" do
     pgp_signed_and_encrypted_part_expectations(mail)
     decrypted_mail = decrypt_mail(mail)
     decrypted_part_expectations_for_text_jpeg_mail(decrypted_mail)
+    resilent_transport_encoding_expectations(decrypted_mail.parts[0])
+    resilent_transport_encoding_expectations(decrypted_mail.parts[1])
   end
 end

--- a/spec/acceptance/gpgme/sign_and_encrypt_encapsulated_spec.rb
+++ b/spec/acceptance/gpgme/sign_and_encrypt_encapsulated_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe "Signing and encrypting in encapsulated fashion with GPGME" do
     decrypted_mail = decrypt_mail(mail)
     pgp_signed_part_expectations(decrypted_mail)
     decrypted_part_expectations_for_simple_mail(decrypted_mail.parts[0])
+    resilent_transport_encoding_expectations(decrypted_mail.parts[0])
   end
 
   specify "a non-multipart HTML message" do
@@ -27,6 +28,7 @@ RSpec.describe "Signing and encrypting in encapsulated fashion with GPGME" do
     decrypted_mail = decrypt_mail(mail)
     pgp_signed_part_expectations(decrypted_mail)
     decrypted_part_expectations_for_simple_html_mail(decrypted_mail.parts[0])
+    resilent_transport_encoding_expectations(decrypted_mail.parts[0])
   end
 
   specify "a multipart text+HTML message" do
@@ -39,6 +41,8 @@ RSpec.describe "Signing and encrypting in encapsulated fashion with GPGME" do
     decrypted_mail = decrypt_mail(mail)
     pgp_signed_part_expectations(decrypted_mail)
     decrypted_part_expectations_for_text_html_mail(decrypted_mail.parts[0])
+    resilent_transport_encoding_expectations(decrypted_mail.parts[0].parts[0])
+    resilent_transport_encoding_expectations(decrypted_mail.parts[0].parts[1])
   end
 
   specify "a multipart message with binary attachments" do
@@ -51,5 +55,7 @@ RSpec.describe "Signing and encrypting in encapsulated fashion with GPGME" do
     decrypted_mail = decrypt_mail(mail)
     pgp_signed_part_expectations(decrypted_mail)
     decrypted_part_expectations_for_text_jpeg_mail(decrypted_mail.parts[0])
+    resilent_transport_encoding_expectations(decrypted_mail.parts[0].parts[0])
+    resilent_transport_encoding_expectations(decrypted_mail.parts[0].parts[1])
   end
 end

--- a/spec/acceptance/gpgme/sign_spec.rb
+++ b/spec/acceptance/gpgme/sign_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe "Signing with GPGME" do
     common_message_expectations(mail)
     pgp_signed_part_expectations(mail)
     decrypted_part_expectations_for_simple_mail(mail.parts[0])
+    resilent_transport_encoding_expectations(mail.parts[0])
   end
 
   specify "a non-multipart HTML message" do
@@ -23,6 +24,7 @@ RSpec.describe "Signing with GPGME" do
     common_message_expectations(mail)
     pgp_signed_part_expectations(mail)
     decrypted_part_expectations_for_simple_html_mail(mail.parts[0])
+    resilent_transport_encoding_expectations(mail.parts[0])
   end
 
   specify "a multipart text+HTML message" do
@@ -33,6 +35,8 @@ RSpec.describe "Signing with GPGME" do
     common_message_expectations(mail)
     pgp_signed_part_expectations(mail)
     decrypted_part_expectations_for_text_html_mail(mail.parts[0])
+    resilent_transport_encoding_expectations(mail.parts[0].parts[0])
+    resilent_transport_encoding_expectations(mail.parts[0].parts[1])
   end
 
   specify "a multipart message with binary attachments" do
@@ -43,6 +47,8 @@ RSpec.describe "Signing with GPGME" do
     common_message_expectations(mail)
     pgp_signed_part_expectations(mail)
     decrypted_part_expectations_for_text_jpeg_mail(mail.parts[0])
+    resilent_transport_encoding_expectations(mail.parts[0].parts[0])
+    resilent_transport_encoding_expectations(mail.parts[0].parts[1])
   end
 
   specify "forcing different signer key" do

--- a/spec/acceptance/rnp/sign_and_encrypt_combined_spec.rb
+++ b/spec/acceptance/rnp/sign_and_encrypt_combined_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe "Signing and encrypting in combined fashion with RNP" do
     pgp_signed_and_encrypted_part_expectations(mail)
     decrypted_mail = decrypt_mail(mail)
     decrypted_part_expectations_for_simple_mail(decrypted_mail)
+    resilent_transport_encoding_expectations(decrypted_mail)
   end
 
   specify "a non-multipart HTML message" do
@@ -25,6 +26,7 @@ RSpec.describe "Signing and encrypting in combined fashion with RNP" do
     pgp_signed_and_encrypted_part_expectations(mail)
     decrypted_mail = decrypt_mail(mail)
     decrypted_part_expectations_for_simple_html_mail(decrypted_mail)
+    resilent_transport_encoding_expectations(decrypted_mail)
   end
 
   specify "a multipart text+HTML message" do
@@ -36,6 +38,8 @@ RSpec.describe "Signing and encrypting in combined fashion with RNP" do
     pgp_signed_and_encrypted_part_expectations(mail)
     decrypted_mail = decrypt_mail(mail)
     decrypted_part_expectations_for_text_html_mail(decrypted_mail)
+    resilent_transport_encoding_expectations(decrypted_mail.parts[0])
+    resilent_transport_encoding_expectations(decrypted_mail.parts[1])
   end
 
   specify "a multipart message with binary attachments" do
@@ -47,5 +51,7 @@ RSpec.describe "Signing and encrypting in combined fashion with RNP" do
     pgp_signed_and_encrypted_part_expectations(mail)
     decrypted_mail = decrypt_mail(mail)
     decrypted_part_expectations_for_text_jpeg_mail(decrypted_mail)
+    resilent_transport_encoding_expectations(decrypted_mail.parts[0])
+    resilent_transport_encoding_expectations(decrypted_mail.parts[1])
   end
 end

--- a/spec/acceptance/rnp/sign_and_encrypt_encapsulated_spec.rb
+++ b/spec/acceptance/rnp/sign_and_encrypt_encapsulated_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe "Signing and encrypting in encapsulated fashion with RNP" do
     decrypted_mail = decrypt_mail(mail)
     pgp_signed_part_expectations(decrypted_mail)
     decrypted_part_expectations_for_simple_mail(decrypted_mail.parts[0])
+    resilent_transport_encoding_expectations(decrypted_mail.parts[0])
   end
 
   specify "a non-multipart HTML message" do
@@ -27,6 +28,7 @@ RSpec.describe "Signing and encrypting in encapsulated fashion with RNP" do
     decrypted_mail = decrypt_mail(mail)
     pgp_signed_part_expectations(decrypted_mail)
     decrypted_part_expectations_for_simple_html_mail(decrypted_mail.parts[0])
+    resilent_transport_encoding_expectations(decrypted_mail.parts[0])
   end
 
   specify "a multipart text+HTML message" do
@@ -39,6 +41,8 @@ RSpec.describe "Signing and encrypting in encapsulated fashion with RNP" do
     decrypted_mail = decrypt_mail(mail)
     pgp_signed_part_expectations(decrypted_mail)
     decrypted_part_expectations_for_text_html_mail(decrypted_mail.parts[0])
+    resilent_transport_encoding_expectations(decrypted_mail.parts[0].parts[0])
+    resilent_transport_encoding_expectations(decrypted_mail.parts[0].parts[1])
   end
 
   specify "a multipart message with binary attachments" do
@@ -51,5 +55,7 @@ RSpec.describe "Signing and encrypting in encapsulated fashion with RNP" do
     decrypted_mail = decrypt_mail(mail)
     pgp_signed_part_expectations(decrypted_mail)
     decrypted_part_expectations_for_text_jpeg_mail(decrypted_mail.parts[0])
+    resilent_transport_encoding_expectations(decrypted_mail.parts[0].parts[0])
+    resilent_transport_encoding_expectations(decrypted_mail.parts[0].parts[1])
   end
 end

--- a/spec/acceptance/rnp/sign_spec.rb
+++ b/spec/acceptance/rnp/sign_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe "Signing with RNP" do
     common_message_expectations(mail)
     pgp_signed_part_expectations(mail)
     decrypted_part_expectations_for_simple_mail(mail.parts[0])
+    resilent_transport_encoding_expectations(mail.parts[0])
   end
 
   specify "a non-multipart HTML message" do
@@ -23,6 +24,7 @@ RSpec.describe "Signing with RNP" do
     common_message_expectations(mail)
     pgp_signed_part_expectations(mail)
     decrypted_part_expectations_for_simple_html_mail(mail.parts[0])
+    resilent_transport_encoding_expectations(mail.parts[0])
   end
 
   specify "a multipart text+HTML message" do
@@ -33,6 +35,8 @@ RSpec.describe "Signing with RNP" do
     common_message_expectations(mail)
     pgp_signed_part_expectations(mail)
     decrypted_part_expectations_for_text_html_mail(mail.parts[0])
+    resilent_transport_encoding_expectations(mail.parts[0].parts[0])
+    resilent_transport_encoding_expectations(mail.parts[0].parts[1])
   end
 
   specify "a multipart message with binary attachments" do
@@ -43,6 +47,8 @@ RSpec.describe "Signing with RNP" do
     common_message_expectations(mail)
     pgp_signed_part_expectations(mail)
     decrypted_part_expectations_for_text_jpeg_mail(mail.parts[0])
+    resilent_transport_encoding_expectations(mail.parts[0].parts[0])
+    resilent_transport_encoding_expectations(mail.parts[0].parts[1])
   end
 
   specify "forcing different signer key" do

--- a/spec/support/expectations_for_example_emails.rb
+++ b/spec/support/expectations_for_example_emails.rb
@@ -79,5 +79,11 @@ shared_context "expectations for example emails" do
       to be_a_pgp_encrypted_message.
       signed_by(expected_signer)
   end
+
+  def resilent_transport_encoding_expectations(message_or_part)
+    expect(
+      message_or_part.content_transfer_encoding
+    ).to eq("base64") | eq("quoted-printable")
+  end
 end
 # rubocop:enable Metrics/AbcSize

--- a/spec/unit/extensions/message_transport_encoding_restrictions_spec.rb
+++ b/spec/unit/extensions/message_transport_encoding_restrictions_spec.rb
@@ -1,0 +1,102 @@
+require "spec_helper"
+
+RSpec.describe EnMail::Extensions::MessageTransportEncodingRestrictions do
+  describe "::identify_and_set_transfer_encoding" do
+    let(:textual_part) do
+      m = Mail::Part.new
+      m.content_type = "text/plain"
+      m.body = "Whatever!"
+      m
+    end
+
+    let(:binary_part) do
+      m = Mail::Part.new
+      m.content_type = "image/jpeg"
+      m.body = SMALLEST_JPEG
+      m
+    end
+
+    let(:multipart) do
+      m = Mail::Part.new
+      m.content_type = "multipart/mixed"
+      m.add_part(textual_part)
+      m.add_part(binary_part)
+      m
+    end
+
+    before do
+      if with_encoding_restrictions
+        ivar = "@enmail_rfc18467_encoding_restrictions"
+        part.instance_variable_set(ivar, true)
+      end
+
+      # The 8bit encoding is universal and most space efficient.  Setting it as
+      # preferred one will prevent Mail gem from escaping any non-ascii
+      # character (by using base64 or quoted-printable encodings).
+      #
+      # Thanks to that, we are able to test whether EnMail's custom restrictions
+      # do work as intended, and override default behaviour.
+      part.transport_encoding = "8bit"
+
+      # Prepare mail part to being sent.  For this examples, it roughly means
+      # "encode message and add proper headers".
+      part.ready_to_send!
+    end
+
+    context "when encoding restrictions are required" do
+      let(:with_encoding_restrictions) { true }
+
+      context "and body looks textual" do
+        let(:part) { textual_part }
+
+        specify "best compatible transport encoding is used (here: 7bit)" do
+          expect(part.content_transfer_encoding).to eq("quoted-printable")
+        end
+      end
+
+      context "and body looks binary" do
+        let(:part) { binary_part }
+
+        specify "best compatible transport encoding is used (here: 8bit)" do
+          expect(part.content_transfer_encoding).to eq("base64")
+        end
+      end
+
+      context "and message or part is compound" do
+        let(:part) { multipart }
+
+        specify "best compatible transport encoding is used" do
+          expect(part.content_transfer_encoding).to eq("8bit")
+        end
+      end
+    end
+
+    context "when encoding restrictions are not required" do
+      let(:with_encoding_restrictions) { false }
+
+      context "and body looks textual" do
+        let(:part) { textual_part }
+
+        specify "best compatible transport encoding is used (here: 7bit)" do
+          expect(part.content_transfer_encoding).to eq("7bit")
+        end
+      end
+
+      context "and body looks binary" do
+        let(:part) { binary_part }
+
+        specify "best compatible transport encoding is used (here: 8bit)" do
+          expect(part.content_transfer_encoding).to eq("8bit")
+        end
+      end
+
+      context "and message or part is compound" do
+        let(:part) { multipart }
+
+        specify "best compatible transport encoding is used" do
+          expect(part.content_transfer_encoding).to eq("8bit")
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/helpers/rfc1847_spec.rb
+++ b/spec/unit/helpers/rfc1847_spec.rb
@@ -37,6 +37,7 @@ RSpec.describe EnMail::Helpers::RFC1847 do
         to receive(:build_encrypted_part).and_return(enc_part_dbl)
       allow(adapter).
         to receive(:encrypt_string).and_return(enc_dummy)
+      allow(adapter).to receive(:restrict_encoding)
     end
 
     it "changes message mime type to multipart/encrypted" do
@@ -96,6 +97,7 @@ RSpec.describe EnMail::Helpers::RFC1847 do
       allow(adapter).to receive(:body_to_part).and_return(msg_part_dbl)
       allow(adapter).to receive(:build_signature_part).and_return(sig_dbl)
       allow(adapter).to receive(:compute_signature).and_return(sig_dummy)
+      allow(adapter).to receive(:restrict_encoding)
     end
 
     it "changes message mime type to multipart/signed" do
@@ -138,6 +140,13 @@ RSpec.describe EnMail::Helpers::RFC1847 do
       subject.(mail)
       expect(adapter).to have_received(:build_signature_part).with(sig_dummy)
       expect(mail.parts[1]).to be(sig_dbl)
+    end
+
+    it "enforces quoted-printable or base64 transport encoding for signed " +
+      "part, but for nothing else" do
+      subject.(mail)
+      expect(adapter).to have_received(:restrict_encoding).once
+      expect(adapter).to have_received(:restrict_encoding).with(msg_part_dbl)
     end
   end
 

--- a/spec/unit/helpers/rfc3156_spec.rb
+++ b/spec/unit/helpers/rfc3156_spec.rb
@@ -24,6 +24,7 @@ RSpec.describe EnMail::Helpers::RFC3156 do
         to receive(:build_encrypted_part).and_return(enc_part_dbl)
       allow(adapter).
         to receive(:sign_and_encrypt_string).and_return(enc_dummy)
+      allow(adapter).to receive(:restrict_encoding)
     end
 
     it "changes message mime type to multipart/encrypted" do
@@ -68,6 +69,13 @@ RSpec.describe EnMail::Helpers::RFC3156 do
       subject.(mail)
       expect(adapter).to have_received(:build_encrypted_part).with(enc_dummy)
       expect(mail.parts[1]).to be(enc_part_dbl)
+    end
+
+    it "enforces quoted-printable or base64 transport encoding for part " +
+      "containing original message (before encryption), but for nothing else" do
+      subject.(mail)
+      expect(adapter).to have_received(:restrict_encoding).once
+      expect(adapter).to have_received(:restrict_encoding).with(msg_part_dbl)
     end
   end
 


### PR DESCRIPTION
Enforces proper `content-transfer-encoding` for MIME parts which are signed (and encrypted) with `:sign` or `:sign sign_and_encrypt_combined` adapter methods.

No changes to `:sign_and_encrypt_encapsulated` are needed, because it uses `:sign` under the hood. Neither `:encrypt` is required to be updated, because it does not compute any signature.

Fixes #72.