### PR TITLE
Change development PGP home location

### DIFF
--- a/spec/support/gpgme_setup.rb
+++ b/spec/support/gpgme_setup.rb
@@ -2,6 +2,6 @@
 # on file name length of the socket, and GPGME makes use of UNIX sockets.
 # Directory name produced by +Dir.mktmpdir+ is often quite long, and that
 # may cause weird error with misleading message.
-TMP_GPGME_HOME = File.expand_path("../../tmp/gpgme", __dir__)
+TMP_GPGME_HOME = File.expand_path("../../tmp/pgp_home", __dir__)
 FileUtils.mkdir_p(TMP_GPGME_HOME)
 GPGME::Engine.home_dir = TMP_GPGME_HOME

--- a/spec/support/rnp_setup.rb
+++ b/spec/support/rnp_setup.rb
@@ -2,7 +2,7 @@
 # on file name length of the socket, and GPGME makes use of UNIX sockets.
 # Directory name produced by +Dir.mktmpdir+ is often quite long, and that
 # may cause weird error with misleading message.
-TMP_RNP_HOME = File.expand_path("../../tmp/gpgme", __dir__)
+TMP_RNP_HOME = File.expand_path("../../tmp/pgp_home", __dir__)
 FileUtils.mkdir_p(TMP_RNP_HOME)
 
 def Rnp.default_homedir


### PR DESCRIPTION
Previous `tmp/gpgme` was somewhat misleading.  It's a common development home directory for all OpenPGP implementations supported by EnMail. `tmp/pgp_home` is much better.