### PR TITLE
Rename a Rake task

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ before_install:
   - gem install bundler -v 1.16.1
 
 before_script:
-  - rake generate_gpg_keys
+  - rake generate_pgp_keys
 
 matrix:
   allow_failures:

--- a/Rakefile
+++ b/Rakefile
@@ -7,7 +7,7 @@ task :default => :spec # rubocop:disable Style/HashSyntax
 
 # Available parameters for unattended GPG key generation are described here:
 # https://www.gnupg.org/documentation/manuals/gnupg/Unattended-GPG-key-generation.html
-task :generate_gpg_keys => :init_gpgme do # rubocop:disable Style/HashSyntax
+task :generate_pgp_keys => :init_gpgme do # rubocop:disable Style/HashSyntax
   ::GPGME::Ctx.new.genkey(<<~SCRIPT)
     <GnupgKeyParms format="internal">
     %no-protection

--- a/bin/setup
+++ b/bin/setup
@@ -14,7 +14,7 @@ bundle install
 #             with GnuPG...            #
 ########################################
 
-bundle exec rake generate_gpg_keys
+bundle exec rake generate_pgp_keys
 
 ########################################
 #          Validating setup...         #


### PR DESCRIPTION
Rename `generate_gpg_keys` Rake task to `generate_pgp_keys`.  These keys are to be used by all OpenPGP implementations supported by EnMail, not just GnuPG.