### PR TITLE
Write more specs for "signer" adapter option

### DIFF
--- a/spec/acceptance/gpgme/sign_and_encrypt_combined_spec.rb
+++ b/spec/acceptance/gpgme/sign_and_encrypt_combined_spec.rb
@@ -54,4 +54,17 @@ RSpec.describe "Signing and encrypting in combined fashion with GPGME" do
     resilent_transport_encoding_expectations(decrypted_mail.parts[0])
     resilent_transport_encoding_expectations(decrypted_mail.parts[1])
   end
+
+  specify "with specific signer key" do
+    mail = simple_mail
+    signer = "whatever@example.test"
+
+    EnMail.protect :sign_and_encrypt_combined, mail, adapter: adapter_class,
+                                                     signer: signer
+    mail.deliver
+    common_message_expectations(mail)
+    pgp_signed_and_encrypted_part_expectations(mail, expected_signer: signer)
+    decrypted_mail = decrypt_mail(mail)
+    decrypted_part_expectations_for_simple_mail(decrypted_mail)
+  end
 end

--- a/spec/acceptance/gpgme/sign_and_encrypt_encapsulated_spec.rb
+++ b/spec/acceptance/gpgme/sign_and_encrypt_encapsulated_spec.rb
@@ -58,4 +58,18 @@ RSpec.describe "Signing and encrypting in encapsulated fashion with GPGME" do
     resilent_transport_encoding_expectations(decrypted_mail.parts[0].parts[0])
     resilent_transport_encoding_expectations(decrypted_mail.parts[0].parts[1])
   end
+
+  specify "with specific signer key" do
+    mail = simple_mail
+    signer = "whatever@example.test"
+
+    EnMail.protect :sign_and_encrypt_encapsulated, mail, adapter: adapter_class,
+                                                         signer: signer
+    mail.deliver
+    common_message_expectations(mail)
+    pgp_encrypted_part_expectations(mail)
+    decrypted_mail = decrypt_mail(mail)
+    pgp_signed_part_expectations(decrypted_mail, expected_signer: signer)
+    decrypted_part_expectations_for_simple_mail(decrypted_mail.parts[0])
+  end
 end

--- a/spec/acceptance/gpgme/sign_spec.rb
+++ b/spec/acceptance/gpgme/sign_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe "Signing with GPGME" do
     resilent_transport_encoding_expectations(mail.parts[0].parts[1])
   end
 
-  specify "forcing different signer key" do
+  specify "with specific signer key" do
     mail = simple_mail
     signer = "whatever@example.test"
 

--- a/spec/acceptance/rnp/sign_and_encrypt_combined_spec.rb
+++ b/spec/acceptance/rnp/sign_and_encrypt_combined_spec.rb
@@ -54,4 +54,17 @@ RSpec.describe "Signing and encrypting in combined fashion with RNP" do
     resilent_transport_encoding_expectations(decrypted_mail.parts[0])
     resilent_transport_encoding_expectations(decrypted_mail.parts[1])
   end
+
+  specify "with specific signer key" do
+    mail = simple_mail
+    signer = "whatever@example.test"
+
+    EnMail.protect :sign_and_encrypt_combined, mail, adapter: adapter_class,
+                                                     signer: signer
+    mail.deliver
+    common_message_expectations(mail)
+    pgp_signed_and_encrypted_part_expectations(mail, expected_signer: signer)
+    decrypted_mail = decrypt_mail(mail)
+    decrypted_part_expectations_for_simple_mail(decrypted_mail)
+  end
 end

--- a/spec/acceptance/rnp/sign_and_encrypt_encapsulated_spec.rb
+++ b/spec/acceptance/rnp/sign_and_encrypt_encapsulated_spec.rb
@@ -58,4 +58,18 @@ RSpec.describe "Signing and encrypting in encapsulated fashion with RNP" do
     resilent_transport_encoding_expectations(decrypted_mail.parts[0].parts[0])
     resilent_transport_encoding_expectations(decrypted_mail.parts[0].parts[1])
   end
+
+  specify "with specific signer key" do
+    mail = simple_mail
+    signer = "whatever@example.test"
+
+    EnMail.protect :sign_and_encrypt_encapsulated, mail, adapter: adapter_class,
+                                                         signer: signer
+    mail.deliver
+    common_message_expectations(mail)
+    pgp_encrypted_part_expectations(mail)
+    decrypted_mail = decrypt_mail(mail)
+    pgp_signed_part_expectations(decrypted_mail, expected_signer: signer)
+    decrypted_part_expectations_for_simple_mail(decrypted_mail.parts[0])
+  end
 end

--- a/spec/acceptance/rnp/sign_spec.rb
+++ b/spec/acceptance/rnp/sign_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe "Signing with RNP" do
     resilent_transport_encoding_expectations(mail.parts[0].parts[1])
   end
 
-  specify "forcing different signer key" do
+  specify "with specific signer key" do
     mail = simple_mail
     signer = "whatever@example.test"
 


### PR DESCRIPTION
The `signer` option can be used both in sign only, and sign+encrypt operations.  However, there were no acceptance specs for the latter.