### PR TITLE
Fix build status badge (once again)

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -2,8 +2,8 @@
 
 image:https://img.shields.io/gem/v/enmail.svg[
 	Gem Version, link="https://rubygems.org/gems/enmail"]
-image:https://travis-ci.org/riboseinc/enmail.svg?branch=master[
-	Build Status, link="https://travis-ci.org/riboseinc/enmail"]
+image:https://img.shields.io/travis/riboseinc/enmail/master.svg[
+	Build Status, link="https://travis-ci.org/riboseinc/enmail/branches"]
 image:https://img.shields.io/codecov/c/github/riboseinc/enmail.svg[
 	Test Coverage, link="https://codecov.io/gh/riboseinc/enmail"]
 image:https://img.shields.io/codeclimate/maintainability/riboseinc/enmail.svg[


### PR DESCRIPTION
It was displaying the result of the last build, not the result of the last build on master branch.

Second attempt after reverting broken #84.