### PR TITLE
Improve specs related to password protected keys

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -16,6 +16,10 @@ namespace :pgp_keys do
     File.write(File.join(TMP_PGP_HOME, "gpg.conf"), <<~GPGCONF)
       personal-digest-preferences SHA512
     GPGCONF
+
+    File.write(File.join(TMP_PGP_HOME, "gpg-agent.conf"), <<~AGENTCONF)
+      default-cache-ttl 0
+    AGENTCONF
   end
 
   def execute_gpg(*options)

--- a/Rakefile
+++ b/Rakefile
@@ -12,7 +12,10 @@ task :default => :spec
 
 namespace :pgp_keys do
   def init_homedir_if_missing
+    return if Dir.exists?(TMP_PGP_HOME)
+
     FileUtils.mkdir_p(TMP_PGP_HOME)
+
     File.write(File.join(TMP_PGP_HOME, "gpg.conf"), <<~GPGCONF)
       personal-digest-preferences SHA512
     GPGCONF


### PR DESCRIPTION
Write adapter unit tests involving password-protected keys, and prevent GPG Agent from caching passwords between tests. Fixes #87.