### PR TITLE
Improve PGP home dir (re)generation

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,7 +8,7 @@ root = true
 charset = utf-8
 end_of_line = lf
 
-[*.{rb,yml}]
+[{*.{rb,yml,rake},Rakefile}]
 indent_style = space
 indent_size = 2
 insert_final_newline = true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -24,3 +24,13 @@ Style/TrailingCommaInArguments:
     # after a single method argument which spans across many lines is confusing,
     # not helpful.  Hence, I'm disabling this cop for all specs.
     - "spec/**/*"
+
+Metrics/BlockLength:
+  Exclude:
+    - "spec/**/*"
+    - "**/*.rake"
+    - "Rakefile"
+
+Style/HashSyntax:
+  Exclude:
+    - "Rakefile"

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,8 @@ before_install:
   - gem install bundler -v 1.16.1
 
 before_script:
-  - rake generate_pgp_keys
+  - rake pgp_keys:generate
+  - rake pgp_keys:list
 
 matrix:
   allow_failures:

--- a/README.adoc
+++ b/README.adoc
@@ -129,10 +129,12 @@ in order to prove your setup's correctness.
 
 === Regenerating OpenPGP keys
 
-If you ever need to regenerate your development OpenPGP keys:
+If you ever need to regenerate your development OpenPGP keys, execute:
 
-1. `rm -rf <project_root>/tmp`
-2. `bundle exec rake generate_pgp_keys`
+[source,sh]
+----
+bundle exec rake pgp_keys:regenerate
+----
 
 NOTE: Always run tests after pulling new changes from the upstream.  If they
 fail, it's likely that OpenPGP keys should be regenerated.

--- a/Rakefile
+++ b/Rakefile
@@ -30,12 +30,12 @@ namespace :pgp_keys do
   end
 
   desc "Lists keys in tmp/pgp_home"
-  task :list => :init_gpgme do
+  task :list => :prepare do
     execute_gpg "--list-keys"
   end
 
   desc "Stops all GPG daemons, and deletes tmp/pgp_home"
-  task :clear => :init_gpgme do
+  task :clear => :prepare do
     if File.exists?(TMP_PGP_HOME)
       system "gpgconf", "--homedir", TMP_PGP_HOME, "--kill", "all"
       FileUtils.remove_entry_secure TMP_PGP_HOME
@@ -46,7 +46,7 @@ namespace :pgp_keys do
   task :regenerate => %i[clear generate]
 
   desc "Generates keys in tmp/pgp_home"
-  task :generate => :init_gpgme do
+  task :generate => :prepare do
     # Key pairs without password
     generate_pgp_keys(<<~KEY_PARAMS)
       %no-protection
@@ -107,6 +107,6 @@ namespace :pgp_keys do
   end
 end
 
-task :init_gpgme do
+task :prepare do
   require_relative "./spec/support/0_tmp_pgp_home"
 end

--- a/Rakefile
+++ b/Rakefile
@@ -29,6 +29,14 @@ namespace :pgp_keys do
     execute_gpg "--list-keys"
   end
 
+  desc "Stops all GPG daemons, and deletes tmp/pgp_home"
+  task :clear => :init_gpgme do
+    if File.exists?(TMP_GPGME_HOME)
+      system "gpgconf", "--homedir", TMP_GPGME_HOME, "--kill", "all"
+      FileUtils.remove_entry_secure TMP_GPGME_HOME
+    end
+  end
+
   desc "Generates keys in tmp/pgp_home"
   task :generate => :init_gpgme do
     # Key pairs without password

--- a/Rakefile
+++ b/Rakefile
@@ -3,12 +3,10 @@ require "rspec/core/rake_task"
 
 RSpec::Core::RakeTask.new(:spec)
 
-task :default => :spec # rubocop:disable Style/HashSyntax
+task :default => :spec
 
 # Available parameters for unattended GPG key generation are described here:
 # https://www.gnupg.org/documentation/manuals/gnupg/Unattended-GPG-key-generation.html
-# rubocop:disable Style/HashSyntax
-# rubocop:disable Metrics/BlockLength
 task :generate_pgp_keys => :init_gpgme do
   # Key pairs without password
   ::GPGME::Ctx.new.genkey(<<~SCRIPT)
@@ -68,8 +66,6 @@ task :generate_pgp_keys => :init_gpgme do
     </GnupgKeyParms>
   SCRIPT
 end
-# rubocop:enable Style/HashSyntax
-# rubocop:enable Metrics/BlockLength
 
 task :init_gpgme do
   require "gpgme"

--- a/Rakefile
+++ b/Rakefile
@@ -37,6 +37,9 @@ namespace :pgp_keys do
     end
   end
 
+  desc "Clears tmp/pgp_home, and generates new set of keys"
+  task :regenerate => %i[clear generate]
+
   desc "Generates keys in tmp/pgp_home"
   task :generate => :init_gpgme do
     # Key pairs without password

--- a/Rakefile
+++ b/Rakefile
@@ -5,74 +5,77 @@ RSpec::Core::RakeTask.new(:spec)
 
 task :default => :spec
 
-# Available parameters for unattended GPG key generation are described here:
-# https://www.gnupg.org/documentation/manuals/gnupg/Unattended-GPG-key-generation.html
-task :generate_pgp_keys => :init_gpgme do
-  # Key pairs without password
-  ::GPGME::Ctx.new.genkey(<<~SCRIPT)
-    <GnupgKeyParms format="internal">
-    %no-protection
-    Key-Type: RSA
-    Key-Usage: sign, cert
-    Key-Length: 2048
-    Subkey-Type: RSA
-    Subkey-Length: 2048
-    Subkey-Usage: encrypt
-    Name-Real: Some Arbitrary Key
-    Name-Email: whatever@example.test
-    Name-Comment: Without passphrase
-    Expire-Date: 0
-    </GnupgKeyParms>
-  SCRIPT
+namespace :pgp_keys do
+  # Available parameters for unattended GPG key generation are described here:
+  # https://www.gnupg.org/documentation/manuals/gnupg/Unattended-GPG-key-generation.html
+  desc "Generates keys in tmp/pgp_home"
+  task :generate => :init_gpgme do
+    # Key pairs without password
+    ::GPGME::Ctx.new.genkey(<<~SCRIPT)
+      <GnupgKeyParms format="internal">
+      %no-protection
+      Key-Type: RSA
+      Key-Usage: sign, cert
+      Key-Length: 2048
+      Subkey-Type: RSA
+      Subkey-Length: 2048
+      Subkey-Usage: encrypt
+      Name-Real: Some Arbitrary Key
+      Name-Email: whatever@example.test
+      Name-Comment: Without passphrase
+      Expire-Date: 0
+      </GnupgKeyParms>
+    SCRIPT
 
-  ::GPGME::Ctx.new.genkey(<<~SCRIPT)
-    <GnupgKeyParms format="internal">
-    %no-protection
-    Key-Type: RSA
-    Key-Usage: sign, cert
-    Key-Length: 2048
-    Subkey-Type: RSA
-    Subkey-Length: 2048
-    Subkey-Usage: encrypt
-    Name-Real: Cato Elder
-    Name-Email: cato.elder@example.test
-    Name-Comment: Without passphrase
-    Expire-Date: 0
-    </GnupgKeyParms>
-  SCRIPT
+    ::GPGME::Ctx.new.genkey(<<~SCRIPT)
+      <GnupgKeyParms format="internal">
+      %no-protection
+      Key-Type: RSA
+      Key-Usage: sign, cert
+      Key-Length: 2048
+      Subkey-Type: RSA
+      Subkey-Length: 2048
+      Subkey-Usage: encrypt
+      Name-Real: Cato Elder
+      Name-Email: cato.elder@example.test
+      Name-Comment: Without passphrase
+      Expire-Date: 0
+      </GnupgKeyParms>
+    SCRIPT
 
-  ::GPGME::Ctx.new.genkey(<<~SCRIPT)
-    <GnupgKeyParms format="internal">
-    %no-protection
-    Key-Type: RSA
-    Key-Usage: sign, cert
-    Key-Length: 2048
-    Subkey-Type: RSA
-    Subkey-Length: 2048
-    Subkey-Usage: encrypt
-    Name-Real: Roman Senate
-    Name-Email: senate@example.test
-    Name-Comment: Without passphrase
-    Expire-Date: 0
-    </GnupgKeyParms>
-  SCRIPT
+    ::GPGME::Ctx.new.genkey(<<~SCRIPT)
+      <GnupgKeyParms format="internal">
+      %no-protection
+      Key-Type: RSA
+      Key-Usage: sign, cert
+      Key-Length: 2048
+      Subkey-Type: RSA
+      Subkey-Length: 2048
+      Subkey-Usage: encrypt
+      Name-Real: Roman Senate
+      Name-Email: senate@example.test
+      Name-Comment: Without passphrase
+      Expire-Date: 0
+      </GnupgKeyParms>
+    SCRIPT
 
-  # Password-protected key pairs
-  ::GPGME::Ctx.new.genkey(<<~SCRIPT)
-    <GnupgKeyParms format="internal">
-    Key-Type: RSA
-    Key-Usage: sign, cert
-    Key-Length: 2048
-    Subkey-Type: RSA
-    Subkey-Length: 2048
-    Subkey-Usage: encrypt
-    Name-Real: Cato Elder
-    Name-Email: cato.elder+pwd@example.test
-    Name-Comment: Password-protected
-    Expire-Date: 0
-    Passphrase: 1234
-    </GnupgKeyParms>
-  SCRIPT
+    # Password-protected key pairs
+    ::GPGME::Ctx.new.genkey(<<~SCRIPT)
+      <GnupgKeyParms format="internal">
+      Key-Type: RSA
+      Key-Usage: sign, cert
+      Key-Length: 2048
+      Subkey-Type: RSA
+      Subkey-Length: 2048
+      Subkey-Usage: encrypt
+      Name-Real: Cato Elder
+      Name-Email: cato.elder+pwd@example.test
+      Name-Comment: Password-protected
+      Expire-Date: 0
+      Passphrase: 1234
+      </GnupgKeyParms>
+    SCRIPT
+  end
 end
 
 task :init_gpgme do

--- a/Rakefile
+++ b/Rakefile
@@ -8,7 +8,12 @@ RSpec::Core::RakeTask.new(:spec)
 task :default => :spec
 
 namespace :pgp_keys do
+  def init_homedir_if_missing
+    FileUtils.mkdir_p(TMP_GPGME_HOME)
+  end
+
   def execute_gpg(*options)
+    init_homedir_if_missing
     common_options = ["--no-permission-warning", "--homedir", TMP_GPGME_HOME]
     cmd = ["gpg", *common_options, *options]
     system(*cmd)

--- a/Rakefile
+++ b/Rakefile
@@ -22,8 +22,12 @@ task :generate_pgp_keys => :init_gpgme do
     Name-Email: whatever@example.test
     Name-Comment: Without passphrase
     Expire-Date: 0
-    %commit
+    </GnupgKeyParms>
+  SCRIPT
 
+  ::GPGME::Ctx.new.genkey(<<~SCRIPT)
+    <GnupgKeyParms format="internal">
+    %no-protection
     Key-Type: RSA
     Key-Usage: sign, cert
     Key-Length: 2048
@@ -34,8 +38,12 @@ task :generate_pgp_keys => :init_gpgme do
     Name-Email: cato.elder@example.test
     Name-Comment: Without passphrase
     Expire-Date: 0
-    %commit
+    </GnupgKeyParms>
+  SCRIPT
 
+  ::GPGME::Ctx.new.genkey(<<~SCRIPT)
+    <GnupgKeyParms format="internal">
+    %no-protection
     Key-Type: RSA
     Key-Usage: sign, cert
     Key-Length: 2048

--- a/Rakefile
+++ b/Rakefile
@@ -9,12 +9,12 @@ task :default => :spec
 
 namespace :pgp_keys do
   def init_homedir_if_missing
-    FileUtils.mkdir_p(TMP_GPGME_HOME)
+    FileUtils.mkdir_p(TMP_PGP_HOME)
   end
 
   def execute_gpg(*options)
     init_homedir_if_missing
-    common_options = ["--no-permission-warning", "--homedir", TMP_GPGME_HOME]
+    common_options = ["--no-permission-warning", "--homedir", TMP_PGP_HOME]
     cmd = ["gpg", *common_options, *options]
     system(*cmd)
   end
@@ -36,9 +36,9 @@ namespace :pgp_keys do
 
   desc "Stops all GPG daemons, and deletes tmp/pgp_home"
   task :clear => :init_gpgme do
-    if File.exists?(TMP_GPGME_HOME)
-      system "gpgconf", "--homedir", TMP_GPGME_HOME, "--kill", "all"
-      FileUtils.remove_entry_secure TMP_GPGME_HOME
+    if File.exists?(TMP_PGP_HOME)
+      system "gpgconf", "--homedir", TMP_PGP_HOME, "--kill", "all"
+      FileUtils.remove_entry_secure TMP_PGP_HOME
     end
   end
 
@@ -108,6 +108,5 @@ namespace :pgp_keys do
 end
 
 task :init_gpgme do
-  require "gpgme"
-  require_relative "./spec/support/gpgme_setup"
+  require_relative "./spec/support/0_tmp_pgp_home"
 end

--- a/Rakefile
+++ b/Rakefile
@@ -24,6 +24,11 @@ namespace :pgp_keys do
     end
   end
 
+  desc "Lists keys in tmp/pgp_home"
+  task :list => :init_gpgme do
+    execute_gpg "--list-keys"
+  end
+
   desc "Generates keys in tmp/pgp_home"
   task :generate => :init_gpgme do
     # Key pairs without password

--- a/bin/setup
+++ b/bin/setup
@@ -14,7 +14,7 @@ bundle install
 #             with GnuPG...            #
 ########################################
 
-bundle exec rake generate_pgp_keys
+bundle exec rake pgp_keys:generate pgp_keys:list
 
 ########################################
 #          Validating setup...         #

--- a/spec/support/0_tmp_pgp_home.rb
+++ b/spec/support/0_tmp_pgp_home.rb
@@ -1,0 +1,5 @@
+# Keep tmp directory as short as possible.  UNIX has some annoying limit
+# on file name length of the socket, and GPGME makes use of UNIX sockets.
+# Directory name produced by +Dir.mktmpdir+ is often quite long, and that
+# may cause weird error with misleading message.
+TMP_PGP_HOME = File.expand_path("../../tmp/pgp_home", __dir__)

--- a/spec/support/gpgme_setup.rb
+++ b/spec/support/gpgme_setup.rb
@@ -1,6 +1,1 @@
-# Keep tmp directory as short as possible.  UNIX has some annoying limit
-# on file name length of the socket, and GPGME makes use of UNIX sockets.
-# Directory name produced by +Dir.mktmpdir+ is often quite long, and that
-# may cause weird error with misleading message.
-TMP_GPGME_HOME = File.expand_path("../../tmp/pgp_home", __dir__)
-GPGME::Engine.home_dir = TMP_GPGME_HOME
+GPGME::Engine.home_dir = TMP_PGP_HOME

--- a/spec/support/gpgme_setup.rb
+++ b/spec/support/gpgme_setup.rb
@@ -3,5 +3,4 @@
 # Directory name produced by +Dir.mktmpdir+ is often quite long, and that
 # may cause weird error with misleading message.
 TMP_GPGME_HOME = File.expand_path("../../tmp/pgp_home", __dir__)
-FileUtils.mkdir_p(TMP_GPGME_HOME)
 GPGME::Engine.home_dir = TMP_GPGME_HOME

--- a/spec/support/matchers/be_a_pgp_encrypted_message.rb
+++ b/spec/support/matchers/be_a_pgp_encrypted_message.rb
@@ -71,7 +71,7 @@ RSpec::Matchers.define :be_a_pgp_encrypted_message do
   end
 
   def gpg_decrypt_command(enc_file)
-    homedir_path = Shellwords.escape(TMP_GPGME_HOME)
+    homedir_path = Shellwords.escape(TMP_PGP_HOME)
     enc_path = Shellwords.escape(enc_file.path)
 
     <<~SH

--- a/spec/support/matchers/be_a_valid_pgp_signature_of.rb
+++ b/spec/support/matchers/be_a_valid_pgp_signature_of.rb
@@ -60,7 +60,7 @@ RSpec::Matchers.define :be_a_valid_pgp_signature_of do |text|
   end
 
   def gpg_verify_command(sig_file, data_file)
-    homedir_path = Shellwords.escape(TMP_GPGME_HOME)
+    homedir_path = Shellwords.escape(TMP_PGP_HOME)
     sig_path = Shellwords.escape(sig_file.path)
     data_path = Shellwords.escape(data_file.path)
 

--- a/spec/support/rnp_setup.rb
+++ b/spec/support/rnp_setup.rb
@@ -1,10 +1,3 @@
-# Keep tmp directory as short as possible.  UNIX has some annoying limit
-# on file name length of the socket, and GPGME makes use of UNIX sockets.
-# Directory name produced by +Dir.mktmpdir+ is often quite long, and that
-# may cause weird error with misleading message.
-TMP_RNP_HOME = File.expand_path("../../tmp/pgp_home", __dir__)
-FileUtils.mkdir_p(TMP_RNP_HOME)
-
 def Rnp.default_homedir
-  TMP_RNP_HOME
+  TMP_PGP_HOME
 end


### PR DESCRIPTION
Rewrite Rake tasks which handle generation of development OpenPGP keys. Big leap towards #86.

1. Don't rely on GPGME, just GnuPG executables. Important from #86 perspective.
2. Add tasks for listing or recreating PGP home. Contain them in a `pgp_keys` namespace.
3. Clean-up related spec support files.
4. Improve Rubocop and EditorConfig setup regarding Rakefiles.