### PR TITLE
Make Rakefile working in Ruby 2.3

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -22,7 +22,7 @@ namespace :pgp_keys do
   # Available parameters for unattended GPG key generation are described here:
   # https://www.gnupg.org/documentation/manuals/gnupg/Unattended-GPG-key-generation.html
   def generate_pgp_keys(key_params)
-    Tempfile.create do |key_params_file|
+    Tempfile.create("gnupg-key-params") do |key_params_file|
       key_params_file.write(key_params)
       key_params_file.close
       execute_gpg("--batch", "--gen-key", in: key_params_file.path)


### PR DESCRIPTION
Before Ruby 2.4, `Tempfile::create` required at least one parameter.

This doesn't address issues referred in f091b62bb77360b5d06525456, therefore build failures are still allowed for this particular Ruby version.  That said, I'm going to disallow them if several consecutive builds for 2.3 on Travis succeed.