### PR TITLE
Have RSpec output in document format in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,9 @@ before_script:
   - rake pgp_keys:generate
   - rake pgp_keys:list
 
+script:
+  - bundle exec rspec --format documentation
+
 matrix:
   allow_failures:
     - rvm: ruby-head


### PR DESCRIPTION
There are situations when this format gives much better insight about what is failing in which example group.