### PR TITLE
Disallow build failures in Travis for Ruby 2.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,4 +47,3 @@ before_script:
 matrix:
   allow_failures:
     - rvm: ruby-head
-    - rvm: 2.3


### PR DESCRIPTION
That weird issue no longer happens.  Few more details on this issue are in PR #91.