### PR TITLE
Install dependencies to cacheable locations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,11 +15,11 @@ env:
     - RNP_VERSION="master"
 
     - DEPS_BUILD_DIR="${TRAVIS_BUILD_DIR}/build"
-    - BOTAN_PREFIX="${TRAVIS_BUILD_DIR}/opt"
-    - JSONC_PREFIX="${TRAVIS_BUILD_DIR}/opt"
-    - RNP_PREFIX="${TRAVIS_BUILD_DIR}/opt"
+    - BOTAN_PREFIX="${TRAVIS_BUILD_DIR}/opt/botan"
+    - JSONC_PREFIX="${TRAVIS_BUILD_DIR}/opt/json-c"
+    - RNP_PREFIX="${TRAVIS_BUILD_DIR}/opt/rnp"
 
-    - LD_LIBRARY_PATH="${TRAVIS_BUILD_DIR}/opt/lib"
+    - LD_LIBRARY_PATH="${BOTAN_PREFIX}/lib:${JSONC_PREFIX}/lib:${RNP_PREFIX}/lib"
 
     - >
       GPG_CONFIGURE_OPTS="--disable-doc --enable-pinentry-curses

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ env:
     - LD_LIBRARY_PATH="${BOTAN_PREFIX}/lib:${JSONC_PREFIX}/lib:${RNP_PREFIX}/lib"
     - LD_RUN_PATH="${GPG_PREFIX}/lib"
 
-    - PATH="${GPG_PREFIX}/bin:${PATH}"
+    - PATH="${RNP_PREFIX}/bin:${GPG_PREFIX}/bin:${PATH}"
 
     # Many of these are supported only in few GPG components, hence bunch of
     # harmless warnings typically shows up.

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,10 @@ env:
     - RNP_VERSION="master"
 
     - DEPS_BUILD_DIR="${TRAVIS_BUILD_DIR}/build"
-    - BOTAN_PREFIX="${TRAVIS_BUILD_DIR}/opt/botan"
-    - JSONC_PREFIX="${TRAVIS_BUILD_DIR}/opt/json-c"
-    - RNP_PREFIX="${TRAVIS_BUILD_DIR}/opt/rnp"
+    - DEPS_PREFIX="${TRAVIS_BUILD_DIR}/opt"
+    - BOTAN_PREFIX="${DEPS_PREFIX}/botan"
+    - JSONC_PREFIX="${DEPS_PREFIX}/json-c"
+    - RNP_PREFIX="${DEPS_PREFIX}/rnp"
 
     - LD_LIBRARY_PATH="${BOTAN_PREFIX}/lib:${JSONC_PREFIX}/lib:${RNP_PREFIX}/lib"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,14 +19,28 @@ env:
     - BOTAN_PREFIX="${DEPS_PREFIX}/botan"
     - JSONC_PREFIX="${DEPS_PREFIX}/json-c"
     - RNP_PREFIX="${DEPS_PREFIX}/rnp"
+    - GPG_PREFIX="${DEPS_PREFIX}/gpg"
 
     - LD_LIBRARY_PATH="${BOTAN_PREFIX}/lib:${JSONC_PREFIX}/lib:${RNP_PREFIX}/lib"
+    - LD_RUN_PATH="${GPG_PREFIX}/lib"
 
+    - PATH="${GPG_PREFIX}/bin:${PATH}"
+
+    # Many of these are supported only in few GPG components, hence bunch of
+    # harmless warnings typically shows up.
     - >
       GPG_CONFIGURE_OPTS="--disable-doc --enable-pinentry-curses
       --disable-pinentry-emacs --disable-pinentry-gtk2 --disable-pinentry-gnome3
       --disable-pinentry-qt --disable-pinentry-qt4 --disable-pinentry-qt5
-      --disable-pinentry-tqt --disable-pinentry-fltk"
+      --disable-pinentry-tqt --disable-pinentry-fltk
+      --prefix=${GPG_PREFIX}
+      --with-libgpg-error-prefix=${GPG_PREFIX}
+      --with-libassuan-prefix=${GPG_PREFIX}
+      --with-libgpg-error-prefix=${GPG_PREFIX}
+      --with-libgcrypt-prefix=${GPG_PREFIX}
+      --with-libassuan-prefix=${GPG_PREFIX}
+      --with-ksba-prefix=${GPG_PREFIX}
+      --with-npth-prefix=${GPG_PREFIX}"
 
 before_install:
   - pushd ci

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,7 @@ env:
       --with-npth-prefix=${GPG_PREFIX}"
 
 before_install:
+  - mkdir -p ${DEPS_PREFIX}
   - pushd ci
   - >
     ./install_gpg_all.sh "${GPG_VERSION}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,18 @@ env:
     - RNP_PREFIX="${DEPS_PREFIX}/rnp"
     - GPG_PREFIX="${DEPS_PREFIX}/gpg"
 
+    # Be aware of differences between LD_LIBRARY_PATH and LD_RUN_PATH.
+    # - http://osr507doc.sco.com/en/tools/ccs_linkedit_dynamic_dirsearch.html
+    # - https://www.hpc.dtu.dk/?page_id=1180
+    #
+    # You should be careful when attempting to replicate following in your
+    # setup, because setting LD_LIBRARY_PATH is often a bad idea.  Nevertheless,
+    # it is okay here in Travis, and actually any attempt to change these led me
+    # to linking failures.  Side note: I am not a Linux expert, and you may be
+    # more lucky.
+    #
+    # I'd be happy to get rid of LD_LIBRARY_PATH eventually in some future
+    # pull request.
     - LD_LIBRARY_PATH="${BOTAN_PREFIX}/lib:${JSONC_PREFIX}/lib:${RNP_PREFIX}/lib"
     - LD_RUN_PATH="${GPG_PREFIX}/lib"
 

--- a/spec/support/expect_correct_gpg_version.rb
+++ b/spec/support/expect_correct_gpg_version.rb
@@ -5,7 +5,9 @@ expected_gpg_version = ENV.fetch("EXPECT_GPG_VERSION", nil)
 
 if expected_gpg_version
   gpg_version_info = ::GPGME::Engine.info.detect do |ei|
-    %r"/bin/gpg\d*\Z" =~ ei.file_name
+    # GPG supports that protocol by definition, see:
+    # https://www.gnupg.org/documentation/manuals/gnupg/Invoking-GPG.html
+    ei.protocol == ::GPGME::PROTOCOL_OpenPGP
   end
 
   actual_gpg_version = gpg_version_info.version


### PR DESCRIPTION
A leap towards #66. Change installation prefix of GnuPG, Botan, JSON-C, and RNP to subdirectories of `${TRAVIS_BUILD_DIR}/opt`, so that they can be cached easier.