### PR TITLE
Make adapters responsible for determining which hash algorithm has been used for message signing

### DIFF
--- a/lib/enmail/adapters/gpgme.rb
+++ b/lib/enmail/adapters/gpgme.rb
@@ -21,12 +21,15 @@ module EnMail
 
       private
 
+      # TODO return actual digest algorithm name instead of pgp-sha1.
       def compute_signature(text, signer)
-        build_crypto.detach_sign(
+        signature = build_crypto.detach_sign(
           text,
           signer: signer,
           password: options[:key_password],
         )
+
+        ["pgp-sha1", signature.to_s]
       end
 
       def encrypt_string(text, recipients)

--- a/lib/enmail/adapters/rnp.rb
+++ b/lib/enmail/adapters/rnp.rb
@@ -30,14 +30,17 @@ module EnMail
 
       private
 
+      # TODO return actual digest algorithm name instead of pgp-sha1.
       def compute_signature(text, signer)
         signer_key = find_key_for(signer, need_secret: true)
 
-        rnp.detached_sign(
+        signature = rnp.detached_sign(
           signers: [signer_key],
           input: build_input(text),
           armored: true,
         )
+
+        ["pgp-sha1", signature]
       end
 
       def encrypt_string(text, recipients)

--- a/lib/enmail/helpers/rfc1847.rb
+++ b/lib/enmail/helpers/rfc1847.rb
@@ -36,12 +36,12 @@ module EnMail
         source_part = body_to_part(message)
         restrict_encoding(source_part)
         signer = find_signer_for(message)
-        signature = compute_signature(source_part.encoded, signer).to_s
+        micalg, signature = compute_signature(source_part.encoded, signer)
         signature_part = build_signature_part(signature)
 
         rewrite_body(
           message,
-          content_type: multipart_signed_content_type,
+          content_type: multipart_signed_content_type(micalg: micalg),
           parts: [source_part, signature_part],
         )
       end

--- a/lib/enmail/helpers/rfc1847.rb
+++ b/lib/enmail/helpers/rfc1847.rb
@@ -85,7 +85,7 @@ module EnMail
         part
       end
 
-      def multipart_signed_content_type(protocol: sign_protocol, micalg: message_integrity_algorithm)
+      def multipart_signed_content_type(protocol: sign_protocol, micalg:)
         %[multipart/signed; protocol="#{protocol}"; micalg="#{micalg}"]
       end
 

--- a/lib/enmail/helpers/rfc1847.rb
+++ b/lib/enmail/helpers/rfc1847.rb
@@ -85,14 +85,11 @@ module EnMail
         part
       end
 
-      def multipart_signed_content_type
-        protocol = sign_protocol
-        micalg = message_integrity_algorithm
+      def multipart_signed_content_type(protocol: sign_protocol, micalg: message_integrity_algorithm)
         %[multipart/signed; protocol="#{protocol}"; micalg="#{micalg}"]
       end
 
-      def multipart_encrypted_content_type
-        protocol = encryption_protocol
+      def multipart_encrypted_content_type(protocol: encryption_protocol)
         %[multipart/encrypted; protocol="#{protocol}"]
       end
 

--- a/lib/enmail/helpers/rfc3156.rb
+++ b/lib/enmail/helpers/rfc3156.rb
@@ -51,10 +51,6 @@ module EnMail
         "application/pgp-encrypted"
       end
 
-      def message_integrity_algorithm
-        "pgp-sha1"
-      end
-
       # As defined in RFC 3156
       def encryption_control_information
         "Version: 1"

--- a/spec/unit/adapters/gpgme_spec.rb
+++ b/spec/unit/adapters/gpgme_spec.rb
@@ -14,9 +14,21 @@ RSpec.describe EnMail::Adapters::GPGME, requires: :gpgme do
     let(:text) { "Some Text." }
     let(:signer) { "cato.elder@example.test" }
 
-    it "computes a detached signature for given text signed by given user" do
+    it "returns a two element array" do
       retval = subject.(text, signer)
-      expect(retval).to be_a_valid_pgp_signature_of(text).signed_by(signer)
+      expect(retval).to be_an(Array)
+      expect(retval.size).to eq(2)
+    end
+
+    it "computes a detached signature for given text signed by given " +
+      "user, and returns it as 2nd element of the returned array" do
+      retval = subject.(text, signer)
+      expect(retval[1]).to be_a_valid_pgp_signature_of(text).signed_by(signer)
+    end
+
+    it "returns a digest algorithm as 1st element of the returned array" do
+      retval = subject.(text, signer)
+      expect(retval[0]).to match(/\Apgp-[a-z0-9]+\z/)
     end
   end
 

--- a/spec/unit/adapters/rnp_spec.rb
+++ b/spec/unit/adapters/rnp_spec.rb
@@ -35,9 +35,21 @@ RSpec.describe EnMail::Adapters::RNP, requires: :rnp do
     let(:text) { "Some Text." }
     let(:signer) { "cato.elder@example.test" }
 
-    it "computes a detached signature for given text signed by given user" do
+    it "returns a two element array" do
       retval = subject.(text, signer)
-      expect(retval).to be_a_valid_pgp_signature_of(text).signed_by(signer)
+      expect(retval).to be_an(Array)
+      expect(retval.size).to eq(2)
+    end
+
+    it "computes a detached signature for given text signed by given " +
+      "user, and returns it as 2nd element of the returned array" do
+      retval = subject.(text, signer)
+      expect(retval[1]).to be_a_valid_pgp_signature_of(text).signed_by(signer)
+    end
+
+    it "returns a digest algorithm as 1st element of the returned array" do
+      retval = subject.(text, signer)
+      expect(retval[0]).to match(/\Apgp-[a-z0-9]+\z/)
     end
   end
 

--- a/spec/unit/helpers/rfc1847_spec.rb
+++ b/spec/unit/helpers/rfc1847_spec.rb
@@ -251,44 +251,77 @@ RSpec.describe EnMail::Helpers::RFC1847 do
 
   describe "#multipart_signed_content_type" do
     subject { adapter.method(:multipart_signed_content_type) }
+    let(:args) { { micalg: "micalg", protocol: "protocol" } }
 
     it "returns a string" do
-      expect(subject.call).to be_a(String)
+      expect(subject.call(args)).to be_a(String)
     end
 
     it "has a MIME type multipart/signed" do
-      retval_segments = subject.call.split(/\s*;\s*/)
+      retval_segments = subject.call(args).split(/\s*;\s*/)
       expect(retval_segments[0]).to eq("multipart/signed")
     end
 
-    it "tells about SHA1 message integrity algorithm" do
-      retval_segments = subject.call.split(/\s*;\s*/)
-      micalg_def = %[micalg="#{custom_micalg}"]
+    it "tells about SHA1 message integrity algorithm given as argument" do
+      # To guarantee it is different from other value defined in helper
+      micalg = "#{custom_micalg}-1"
+      args[:micalg] = micalg
+      retval_segments = subject.call(args).split(/\s*;\s*/)
+      micalg_def = %[micalg="#{micalg}"]
       expect(retval_segments[1..-1]).to include(micalg_def)
     end
 
-    it "tells about PGP protocol" do
-      retval_segments = subject.call.split(/\s*;\s*/)
-      protocol_def = %[protocol="#{custom_sign_protocol}"]
+    it "defaults micalg argument to value returned by " +
+      "#message_integrity_algorithm" do
+      args.delete :micalg
+      retval_segments = subject.call(args).split(/\s*;\s*/)
+      micalg_def = %[micalg="#{adapter.message_integrity_algorithm}"]
+      expect(retval_segments[1..-1]).to include(micalg_def)
+    end
+
+    it "tells about PGP protocol given as argument" do
+      # To guarantee it is different from other value defined in helper
+      sign_protocol = "#{custom_sign_protocol}-1"
+      args[:protocol] = sign_protocol
+      retval_segments = subject.call(args).split(/\s*;\s*/)
+      protocol_def = %[protocol="#{sign_protocol}"]
+      expect(retval_segments[1..-1]).to include(protocol_def)
+    end
+
+    it "defaults protocol argument to value returned by #sign_protocol" do
+      args.delete :protocol
+      retval_segments = subject.call(args).split(/\s*;\s*/)
+      protocol_def = %[protocol="#{adapter.sign_protocol}"]
       expect(retval_segments[1..-1]).to include(protocol_def)
     end
   end
 
   describe "#multipart_encrypted_content_type" do
     subject { adapter.method(:multipart_encrypted_content_type) }
+    let(:args) { { protocol: "protocol" } }
 
     it "returns a string" do
-      expect(subject.call).to be_a(String)
+      expect(subject.call(args)).to be_a(String)
     end
 
     it "has a MIME type multipart/encrypted" do
-      retval_segments = subject.call.split(/\s*;\s*/)
+      retval_segments = subject.call(args).split(/\s*;\s*/)
       expect(retval_segments[0]).to eq("multipart/encrypted")
     end
 
-    it "tells about PGP protocol" do
-      retval_segments = subject.call.split(/\s*;\s*/)
-      protocol_def = %[protocol="#{custom_enc_protocol}"]
+    it "tells about PGP protocol given as argument" do
+      # To guarantee it is different from other value defined in helper
+      encryption_protocol = "#{custom_enc_protocol}-1"
+      args[:protocol] = encryption_protocol
+      retval_segments = subject.call(args).split(/\s*;\s*/)
+      protocol_def = %[protocol="#{encryption_protocol}"]
+      expect(retval_segments[1..-1]).to include(protocol_def)
+    end
+
+    it "defaults protocol argument to value returned by #encryption_protocol" do
+      args.delete :protocol
+      retval_segments = subject.call(args).split(/\s*;\s*/)
+      protocol_def = %[protocol="#{adapter.encryption_protocol}"]
       expect(retval_segments[1..-1]).to include(protocol_def)
     end
   end

--- a/spec/unit/helpers/rfc1847_spec.rb
+++ b/spec/unit/helpers/rfc1847_spec.rb
@@ -273,12 +273,9 @@ RSpec.describe EnMail::Helpers::RFC1847 do
       expect(retval_segments[1..-1]).to include(micalg_def)
     end
 
-    it "defaults micalg argument to value returned by " +
-      "#message_integrity_algorithm" do
+    it "requires micalg argument" do
       args.delete :micalg
-      retval_segments = subject.call(args).split(/\s*;\s*/)
-      micalg_def = %[micalg="#{adapter.message_integrity_algorithm}"]
-      expect(retval_segments[1..-1]).to include(micalg_def)
+      expect { subject.call(args) }.to raise_error(ArgumentError)
     end
 
     it "tells about PGP protocol given as argument" do

--- a/spec/unit/helpers/rfc1847_spec.rb
+++ b/spec/unit/helpers/rfc1847_spec.rb
@@ -95,11 +95,13 @@ RSpec.describe EnMail::Helpers::RFC1847 do
     let(:msg_part_dbl) { double.as_null_object }
     let(:sig_dbl) { double.as_null_object }
     let(:sig_dummy) { "DUMMY-PGP-SIGNATURE" }
+    let(:mic_dummy) { "pgp-dummy" }
 
     before do
       allow(adapter).to receive(:body_to_part).and_return(msg_part_dbl)
       allow(adapter).to receive(:build_signature_part).and_return(sig_dbl)
-      allow(adapter).to receive(:compute_signature).and_return(sig_dummy)
+      allow(adapter).to receive(:compute_signature).
+        and_return([mic_dummy, sig_dummy])
       allow(adapter).to receive(:restrict_encoding)
     end
 


### PR DESCRIPTION
According to RFC1847, a "multipart/signed" MIME type must be supplied with "micalg" parameter, which tells which hash algorithm has been used in signature calculation. Whereas signature part contains this information as well, declaring this in advance allows for signature verification in one-pass processing.

Fixes #101.