### PR TITLE
Use SHA512 in signatures in RNP adapter

### DIFF
--- a/lib/enmail/adapters/rnp.rb
+++ b/lib/enmail/adapters/rnp.rb
@@ -107,7 +107,7 @@ module EnMail
       end
 
       def hash_algorithm
-        "SHA1"
+        "SHA512"
       end
     end
   end

--- a/lib/enmail/adapters/rnp.rb
+++ b/lib/enmail/adapters/rnp.rb
@@ -38,9 +38,10 @@ module EnMail
           signers: [signer_key],
           input: build_input(text),
           armored: true,
+          hash: hash_algorithm,
         )
 
-        ["pgp-sha1", signature]
+        ["pgp-#{hash_algorithm.downcase}", signature]
       end
 
       def encrypt_string(text, recipients)
@@ -64,6 +65,7 @@ module EnMail
           signers: signer_key,
           input: build_input(text),
           armored: true,
+          hash: hash_algorithm,
         )
       end
 
@@ -102,6 +104,10 @@ module EnMail
       def homedir_info
         @homedir_info ||=
           ::Rnp.homedir_info(options[:homedir] || Rnp.default_homedir)
+      end
+
+      def hash_algorithm
+        "SHA1"
       end
     end
   end

--- a/spec/support/expectations_for_example_emails.rb
+++ b/spec/support/expectations_for_example_emails.rb
@@ -40,10 +40,12 @@ shared_context "expectations for example emails" do
     expect(message.subject).to eq(mail_subject)
   end
 
-  def pgp_signed_part_expectations(message_or_part, expected_signer: mail_from)
+  def pgp_signed_part_expectations(message_or_part, expected_signer: mail_from,
+    expected_micalg: default_expected_micalg)
+
     expect(message_or_part.mime_type).to eq("multipart/signed")
     expect(message_or_part.content_type_parameters).to include(
-      "micalg" => "pgp-sha1",
+      "micalg" => expected_micalg,
       "protocol" => "application/pgp-signature",
     )
     expect(message_or_part.parts.size).to eq(2)

--- a/spec/support/gpgme_spec_helpers.rb
+++ b/spec/support/gpgme_spec_helpers.rb
@@ -12,4 +12,8 @@ shared_context "gpgme spec helpers" do
   def adapter_class
     ::EnMail::Adapters::GPGME
   end
+
+  def default_expected_micalg
+    "pgp-sha1"
+  end
 end

--- a/spec/support/rnp_spec_helpers.rb
+++ b/spec/support/rnp_spec_helpers.rb
@@ -15,4 +15,8 @@ shared_context "rnp spec helpers" do
   def adapter_class
     ::EnMail::Adapters::RNP
   end
+
+  def default_expected_micalg
+    "pgp-sha1"
+  end
 end

--- a/spec/support/rnp_spec_helpers.rb
+++ b/spec/support/rnp_spec_helpers.rb
@@ -17,6 +17,6 @@ shared_context "rnp spec helpers" do
   end
 
   def default_expected_micalg
-    "pgp-sha1"
+    "pgp-sha512"
   end
 end


### PR DESCRIPTION
Ensures that hash algorithm used in RNP adapter is SHA512, and that "pgp-sha512" is returned from `#compute_signature`, which is then used as micalg parameter of "multipart/signed" MIME type. Fixes #106.