### PR TITLE
Enhance gem documentation

### DIFF
--- a/.yardopts
+++ b/.yardopts
@@ -2,3 +2,5 @@
 README.adoc
 CODE_OF_CONDUCT.md
 LICENSE.txt
+docs/GPGMEAdapter.adoc
+docs/RNPAdapter.adoc

--- a/.yardopts
+++ b/.yardopts
@@ -1,0 +1,4 @@
+-
+README.adoc
+CODE_OF_CONDUCT.md
+LICENSE.txt

--- a/README.adoc
+++ b/README.adoc
@@ -1,5 +1,6 @@
 = EnMail
 
+ifdef::env-github[]
 image:https://img.shields.io/gem/v/enmail.svg[
 	Gem Version, link="https://rubygems.org/gems/enmail"]
 image:https://img.shields.io/travis/riboseinc/enmail/master.svg[
@@ -8,6 +9,7 @@ image:https://img.shields.io/codecov/c/github/riboseinc/enmail.svg[
 	Test Coverage, link="https://codecov.io/gh/riboseinc/enmail"]
 image:https://img.shields.io/codeclimate/maintainability/riboseinc/enmail.svg[
 	"Code Climate", link="https://codeclimate.com/github/riboseinc/enmail"]
+endif::[]
 
 EnMail (encrypted mail) signs or encrypts correspondence sent via the Ruby
 https://rubygems.org/gems/mail[mail] gem.

--- a/README.adoc
+++ b/README.adoc
@@ -47,60 +47,14 @@ EnMail.protect :sign_and_encrypt_combined, mail, adapter: adapter
 
 == Adapters
 
-=== RNP
-
-`RNP` adapter provides OpenPGP-compliant cryptography via
-https://www.rnpgp.com/[RNP] library.
-
-==== Dependencies
-
-This adapter requries two additional pieces of software to be installed:
-
-1. RNP library, version 0.9.2 or newer
-2. `https://rubygems.org/gems/rnp[rnp]` gem, version 1.0.1 or newer
-
-==== Options
-
-Following adapter-specific options are supported:
-
-`homedir`::
-Optional.  Path to RNP home directory, which contains public and secret
-keyrings.  In most situations, RNP is able to read GnuPG home directories,
-hence it's common to set it to `<your_home_directory>/.gpg`.  Defaults to
-`<your_home_directory>/.rnp`.
-`signer`::
-Optional.  User id or e-mail which identifies key which will be used for message
-signing.  By default, first address from mail's From field is used.
-`key_password`::
-Optional.  Password for signer's key.  Can be a string or proc, see
-`rnp` gem documentation for `Rnp#password_provider=`.
-
-=== GPGME
-
-`GPGME` adapter provides OpenPGP-compliant cryptography via
-https://gnupg.org/software/gpgme/index.html[GnuPG Made Easy] library.
-
-==== Dependencies
-
-This adapter requries two additional pieces of software to be installed:
-
-1. GnuPG, version 2.2
-2. `https://rubygems.org/gems/gpgme[gpgme]` gem
-
-==== Options
-
-Following adapter-specific options are supported:
-
-`signer`::
-Optional.  User id or e-mail which identifies key which will be used for message
-signing.  By default, first address from mail's From field is used.
-`key_password`::
-Optional.  Password for signer's key.  Must be a string.
-
-==== Caveats
-
-If you want to use home directory in a non-standard location, change it for
-whole GPGME in following way: `GPGME::Engine.home_dir = 'path/to/home_dir'`
+ifdef::env-browser,env-github[]
+* <<docs/GPGMEAdapter.adoc#,GPGME>>
+* <<docs/RNPAdapter.adoc#,RNP>>
+endif::[]
+ifndef::env-browser,env-github[]
+* {file:docs/GPGMEAdapter.adoc}
+* {file:docs/RNPAdapter.adoc}
+endif::[]
 
 == Development
 

--- a/README.adoc
+++ b/README.adoc
@@ -47,6 +47,22 @@ EnMail.protect :sign_and_encrypt_combined, mail, adapter: adapter
 
 == Adapters
 
+.Adapter features comparison
+[options="header"]
+|=======
+|                    | GPGME    | RNP
+| Protocol           | Open PGP | Open PGP
+| Supporting library | https://gnupg.org/software/gpgme/index.html[GnuPG Made Easy] | https://www.rnpgp.com/[RNP]
+| Native extensions  | yes      | yes, from https://github.com/ffi/ffi[FFI]
+| Sign               | yes      | yes
+| Encrypt            | yes      | yes
+| Sign and encrypt   | yes, encapsulated and combined | yes, encapsulated and combined
+| Password-protected keys | yes, password must be a String | yes, password must be a String or Proc
+| Bugs, issues and feature requests | https://github.com/riboseinc/enmail/issues?q=is%3Aissue+is%3Aopen+label%3A%22adapter%3A+gpgme%22[See GitHub] | https://github.com/riboseinc/enmail/issues?q=is%3Aissue+is%3Aopen+label%3A%22adapter%3A+rnp%22[See GitHub]
+|=======
+
+See adapter-specific guides for details:
+
 ifdef::env-browser,env-github[]
 * <<docs/GPGMEAdapter.adoc#,GPGME>>
 * <<docs/RNPAdapter.adoc#,RNP>>

--- a/docs/GPGMEAdapter.adoc
+++ b/docs/GPGMEAdapter.adoc
@@ -24,3 +24,8 @@ Optional.  Password for signer's key.  Must be a string.
 
 If you want to use home directory in a non-standard location, change it for
 whole GPGME in following way: `GPGME::Engine.home_dir = 'path/to/home_dir'`
+
+== Issue tracker
+
+Bugs, feature requests, and other issues are tracked with `adapter: gpgme`
+label: https://github.com/riboseinc/enmail/issues?q=is%3Aissue+is%3Aopen+label%3A%22adapter%3A+gpgme%22

--- a/docs/GPGMEAdapter.adoc
+++ b/docs/GPGMEAdapter.adoc
@@ -20,12 +20,49 @@ signing.  By default, first address from mail's From field is used.
 `key_password`::
 Optional.  Password for signer's key.  Must be a string.
 
-== Caveats
+== Non-standard home directory location
 
-If you want to use home directory in a non-standard location, change it for
-whole GPGME in following way: `GPGME::Engine.home_dir = 'path/to/home_dir'`
+GnuPG home directory is a place where configuration, keyrings, etc. are stored.
+By default, GnuPG home directory is located in `$HOME/.gnupg`.  You can change
+it in a following way:
+
+[source,ruby]
+----
+::GPGME::Engine.home_dir = 'path/to/home_dir'
+----
+
+Be advised that this setting is global.  Hence, if you use GPGME outside EnMail
+as well, your other logic will be affected.  One possible workaround is to sign
+e-mails in a different process.  This should be fairly easy to achieve in Rails,
+as mailing is often handed to some kind of background job processor which runs
+in its own process.  Nevertheless, consider switching to RNP adapter if this
+limitation poses a problem.
+
+== Using `gpg.conf`
+
+GPGME API accepts little configuration options.  Instead, it reads preferences
+from a `gpg.conf` file located in GnuPG home directory (usually `$HOME/.gnupg`).
+You may override defaults there, i.e. set preferred keys or algorithms.
+Refer to GnuPG documentation for
+https://www.gnupg.org/documentation/manuals/gnupg/GPG-Configuration.html[more
+information about configuration files], or for
+https://www.gnupg.org/documentation/manuals/gnupg/GPG-Options.html[list of
+available options].  Also, you will find some nice example `gpg.conf` in this
+https://stackoverflow.com/a/34923350/304175[Stack Overflow answer].
+
+== Native extensions
+
+The `gpgme` gem includes C extensions.
 
 == Issue tracker
 
 Bugs, feature requests, and other issues are tracked with `adapter: gpgme`
 label: https://github.com/riboseinc/enmail/issues?q=is%3Aissue+is%3Aopen+label%3A%22adapter%3A+gpgme%22
+
+== External links
+
+* https://tools.ietf.org/html/rfc1847[RFC 1847 "Security Multiparts for MIME"]
+* https://tools.ietf.org/html/rfc3156[RFC 3156 "MIME Security with OpenPGP"]
+* https://gnupg.org[GNU Privacy Guard home site]
+* https://gnupg.org/software/gpgme/index.html[GPGME (GnuPG Made Easy) library home site]
+* https://github.com/ueno/ruby-gpgme[Ruby bindings for GPGME library]

--- a/docs/GPGMEAdapter.adoc
+++ b/docs/GPGMEAdapter.adoc
@@ -1,0 +1,26 @@
+= GPGME Adapter Guide
+
+`GPGME` adapter provides OpenPGP-compliant cryptography via
+https://gnupg.org/software/gpgme/index.html[GnuPG Made Easy] library.
+
+== Dependencies
+
+This adapter requries two additional pieces of software to be installed:
+
+1. GnuPG, version 2.2
+2. `https://rubygems.org/gems/gpgme[gpgme]` gem
+
+== Options
+
+Following adapter-specific options are supported:
+
+`signer`::
+Optional.  User id or e-mail which identifies key which will be used for message
+signing.  By default, first address from mail's From field is used.
+`key_password`::
+Optional.  Password for signer's key.  Must be a string.
+
+== Caveats
+
+If you want to use home directory in a non-standard location, change it for
+whole GPGME in following way: `GPGME::Engine.home_dir = 'path/to/home_dir'`

--- a/docs/RNPAdapter.adoc
+++ b/docs/RNPAdapter.adoc
@@ -26,7 +26,20 @@ signing.  By default, first address from mail's From field is used.
 Optional.  Password for signer's key.  Can be a string or proc, see
 `rnp` gem documentation for `Rnp#password_provider=`.
 
+== Native extensions
+
+The `rnp` gem depends on `https://github.com/ffi/ffi[ffi]` gem, which includes
+native extensions.
+
 == Issue tracker
 
 Bugs, feature requests, and other issues are tracked with `adapter: rnp`
 label: https://github.com/riboseinc/enmail/issues?q=is%3Aissue+is%3Aopen+label%3A%22adapter%3A+rnp%22
+
+== External links
+
+* https://tools.ietf.org/html/rfc1847[RFC 1847 "Security Multiparts for MIME"]
+* https://tools.ietf.org/html/rfc3156[RFC 3156 "MIME Security with OpenPGP"]
+* https://www.rnpgp.com[RNP library home site]
+* https://github.com/riboseinc/rnp[RNP library on GitHub]
+* https://github.com/riboseinc/ruby-rnp[Ruby bindings for RNP library]

--- a/docs/RNPAdapter.adoc
+++ b/docs/RNPAdapter.adoc
@@ -25,3 +25,8 @@ signing.  By default, first address from mail's From field is used.
 `key_password`::
 Optional.  Password for signer's key.  Can be a string or proc, see
 `rnp` gem documentation for `Rnp#password_provider=`.
+
+== Issue tracker
+
+Bugs, feature requests, and other issues are tracked with `adapter: rnp`
+label: https://github.com/riboseinc/enmail/issues?q=is%3Aissue+is%3Aopen+label%3A%22adapter%3A+rnp%22

--- a/docs/RNPAdapter.adoc
+++ b/docs/RNPAdapter.adoc
@@ -1,0 +1,27 @@
+= RNP Adapter Guide
+
+`RNP` adapter provides OpenPGP-compliant cryptography via
+https://www.rnpgp.com/[RNP] library.
+
+== Dependencies
+
+This adapter requries two additional pieces of software to be installed:
+
+1. RNP library, version 0.9.2 or newer
+2. `https://rubygems.org/gems/rnp[rnp]` gem, version 1.0.1 or newer
+
+== Options
+
+Following adapter-specific options are supported:
+
+`homedir`::
+Optional.  Path to RNP home directory, which contains public and secret
+keyrings.  In most situations, RNP is able to read GnuPG home directories,
+hence it's common to set it to `<your_home_directory>/.gpg`.  Defaults to
+`<your_home_directory>/.rnp`.
+`signer`::
+Optional.  User id or e-mail which identifies key which will be used for message
+signing.  By default, first address from mail's From field is used.
+`key_password`::
+Optional.  Password for signer's key.  Can be a string or proc, see
+`rnp` gem documentation for `Rnp#password_provider=`.


### PR DESCRIPTION
1. Extract adapter guides from README.
2. Add adapter features comparison table to README.
3. Add more content to documentation, notably describing how to deal with GPGME issues.