### PR TITLE
Allow Bundler 2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,7 +66,7 @@ before_install:
   - ./install_json_c.sh
   - ./install_rnp.sh
   - popd
-  - gem install bundler -v 1.16.3
+  - gem install bundler -v "~> 2.0"
 
 before_script:
   - bundle exec rake pgp_keys:generate

--- a/enmail.gemspec
+++ b/enmail.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "mail", "~> 2.6.4"
 
-  spec.add_development_dependency "bundler", "~> 1.14"
+  spec.add_development_dependency "bundler", ">= 1.14", "< 3.0"
   spec.add_development_dependency "pry", ">= 0.10.3", "< 0.12"
   spec.add_development_dependency "rake", ">= 10", "< 13"
   spec.add_development_dependency "rspec", "~> 3.0"


### PR DESCRIPTION
Bundler 2.0 has been released recently. This pull request relaxes dependency constraint which is specified in gemspec in order to allow all 2.x versions.