### PR TITLE
Move GPGME and RNP dependencies to gemspec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,5 +9,5 @@ gemspec
 gem "codecov", require: false, group: :test
 gem "simplecov", require: false, group: :test
 
-gem "gpgme" unless ENV["TEST_WITHOUT_GPGME"]
-gem "rnp", ">= 1.0.1", "< 2" unless ENV["TEST_WITHOUT_RNP"]
+gem "gpgme", install_if: -> { !ENV["TEST_WITHOUT_GPGME"] }
+gem "rnp", install_if: -> { !ENV["TEST_WITHOUT_RNP"] }

--- a/enmail.gemspec
+++ b/enmail.gemspec
@@ -29,8 +29,10 @@ Gem::Specification.new do |spec|
   spec.add_dependency "mail", "~> 2.6.4"
 
   spec.add_development_dependency "bundler", ">= 1.14", "< 3.0"
+  spec.add_development_dependency "gpgme"
   spec.add_development_dependency "pry", ">= 0.10.3", "< 0.12"
   spec.add_development_dependency "rake", ">= 10", "< 13"
+  spec.add_development_dependency "rnp", ">= 1.0.1", "< 2"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "rspec-pgp_matchers", "~> 0.1.1"
 end


### PR DESCRIPTION
Use `install_if` from Bundler's DSL to distinguish whether they should be installed or not.