### PR TITLE
Display slowest test examples in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -74,7 +74,7 @@ before_script:
   - bundle exec rake pgp_keys:list
 
 script:
-  - bundle exec rspec --format documentation
+  - bundle exec rspec --format documentation --profile 200
 
 matrix:
   include:


### PR DESCRIPTION
Up to 200 the slowest test examples are shown.  This may seem oddly much, but is necessary to display differences between various adapters.

I expect that one adapter will usually occupy about fifty first places.