### PR TITLE
Declare optional dependencies in gemspec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,5 +9,5 @@ gemspec
 gem "codecov", require: false, group: :test
 gem "simplecov", require: false, group: :test
 
-gem "gpgme" unless ENV["TEST_WITHOUT_GPGME"]
-gem "rnp", ">= 1.0.1", "< 2" unless ENV["TEST_WITHOUT_RNP"]
+gem "gpgme", install_if: -> { !ENV["TEST_WITHOUT_GPGME"] }
+gem "rnp", install_if: -> { !ENV["TEST_WITHOUT_RNP"] }

--- a/enmail.gemspec
+++ b/enmail.gemspec
@@ -29,8 +29,10 @@ Gem::Specification.new do |spec|
   spec.add_dependency "mail", "~> 2.6.4"
 
   spec.add_development_dependency "bundler", ">= 1.14", "< 3.0"
+  spec.add_development_dependency "gpgme"
   spec.add_development_dependency "pry", ">= 0.10.3", "< 0.12"
   spec.add_development_dependency "rake", ">= 10", "< 13"
+  spec.add_development_dependency "rnp", ">= 1.0.1", "< 2"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "rspec-pgp_matchers", "~> 0.1.1"
 end


### PR DESCRIPTION
RNP and GPGME gems are optional runtime dependencies of EnMail (at least one of them is required at the moment). However, due to the lack of concept of optional dependencies in RubyGems, they need to be declared as development dependencies.

This pull request moves these dependencies from Gemfile to gemspec, so at least they are included in EnMail's metadata. In order to provide means to test EnMail with only a subset of optional dependencies installed, the `install_if` option from Bundler's DSL has been used.