### PR TITLE
Support Mail 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -85,6 +85,10 @@ matrix:
     - env: TEST_WITHOUT_GPGME="1"
     # Test against older GPG versions
     - env: GPG_VERSION="2.1" EXPECT_GPG_VERSION="2.1"
+    - gemfile: "ci/Mail-2.6.4.gemfile"
+    - gemfile: "ci/Mail-2.6.gemfile"
+    - gemfile: "ci/Mail-head.gemfile"
 
   allow_failures:
     - rvm: ruby-head
+    - gemfile: "ci/Mail-head.gemfile"

--- a/ci/Mail-2.6.4.gemfile
+++ b/ci/Mail-2.6.4.gemfile
@@ -1,0 +1,3 @@
+eval_gemfile "../Gemfile"
+
+gem "mail", "= 2.6.4"

--- a/ci/Mail-2.6.gemfile
+++ b/ci/Mail-2.6.gemfile
@@ -1,0 +1,3 @@
+eval_gemfile "../Gemfile"
+
+gem "mail", "~> 2.6.0"

--- a/ci/Mail-head.gemfile
+++ b/ci/Mail-head.gemfile
@@ -1,0 +1,3 @@
+eval_gemfile "../Gemfile"
+
+gem "mail", github: "mikel/mail"

--- a/enmail.gemspec
+++ b/enmail.gemspec
@@ -32,7 +32,11 @@ Gem::Specification.new do |spec|
   # Mail 2.6.4 has been released on March 23, 2016, hence should be considered
   # old enough.  Nevertheless, pull requests which extend compatibility will be
   # accepted.
-  spec.add_dependency "mail", "~> 2.6.4"
+  #
+  # Version 2.7.0 has been blacklisted due to some bug (not sure which one
+  # exactly) in that version, which is fatal for EnMail.  That bug has been
+  # fixed in 2.7.1.
+  spec.add_dependency "mail", "~> 2.6", ">= 2.6.4", "!= 2.7.0"
 
   spec.add_development_dependency "bundler", ">= 1.14", "< 3.0"
   spec.add_development_dependency "gpgme", *EnMail::DependencyConstraints::GPGME

--- a/lib/enmail/helpers/message_manipulation.rb
+++ b/lib/enmail/helpers/message_manipulation.rb
@@ -25,11 +25,21 @@ module EnMail
         part = ::Mail::Part.new
         part.content_type = message.content_type
         if message.multipart?
-          message.body.parts.each { |p| part.add_part p.dup }
+          message.body.parts.each { |p| part.add_part duplicate_part(p) }
         else
           part.body = message.body.decoded
         end
         part
+      end
+
+      # Duplicates a message part, preserving its Content-ID if present.
+      #
+      # @param [Mail::Part] part message part
+      # @return [Mail::Part] duplicate of +part+
+      def duplicate_part(part)
+        duplicate = part.dup
+        duplicate.add_content_id(part.content_id) unless part.content_id.nil?
+        duplicate
       end
 
       # Detects a list of e-mails which should be used to define a list of


### PR DESCRIPTION
Add support for newest versions of Mail, that is 2.7.x (with exception of buggy 2.7.0).

Due to differences between Mail versions in how `Mail::Part` instances are duplicated, custom `#duplicate_part` helper has been introduced, which copies mail part and its content, preserving Content-ID headers.

Also, Travis CI build matrix has been augmented in order to test EnMail against set of Mail versions.